### PR TITLE
Feature/android/#34 search event:일정 검색 ui 작성

### DIFF
--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/searchevent/SearchEventActivity.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/searchevent/SearchEventActivity.kt
@@ -24,6 +24,8 @@ class SearchActivity : BaseActivity<ActivitySearchEventBinding>(
             searchEventSv.setupWithSearchBar(searchEventSb)
             searchEventSpinner.setSelection(1)
         }
+
+        setDatePicker()
     }
 
     private fun setDatePicker() {

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/searchevent/SearchEventActivity.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/searchevent/SearchEventActivity.kt
@@ -2,9 +2,13 @@ package com.teameetmeet.meetmeet.presentation.searchevent
 
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.datepicker.MaterialDatePicker
 import com.teameetmeet.meetmeet.R
 import com.teameetmeet.meetmeet.databinding.ActivitySearchEventBinding
 import com.teameetmeet.meetmeet.presentation.base.BaseActivity
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 class SearchActivity : BaseActivity<ActivitySearchEventBinding>(
     R.layout.activity_search_event
@@ -19,6 +23,27 @@ class SearchActivity : BaseActivity<ActivitySearchEventBinding>(
             lifecycleOwner = this@SearchActivity
             searchEventSv.setupWithSearchBar(searchEventSb)
             searchEventSpinner.setSelection(1)
+        }
+    }
+
+    private fun setDatePicker() {
+        val datePickerBuilder =
+            MaterialDatePicker.Builder.dateRangePicker()
+                .setTitleText(getString(R.string.search_event_title))
+
+        binding.searchEventTvDateRange.setOnClickListener {
+            datePickerBuilder.build().apply {
+                this.addOnPositiveButtonClickListener {
+                    viewModel.setSearchDateRange(it)
+                    binding.searchEventSpinner.setSelection(0)
+                }
+            }.show(supportFragmentManager, "datePicker")
+        }
+
+        lifecycleScope.launch {
+            viewModel.searchDateRange.collectLatest {
+                datePickerBuilder.setSelection(it)
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/searchevent/SearchEventActivity.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/searchevent/SearchEventActivity.kt
@@ -1,0 +1,24 @@
+package com.teameetmeet.meetmeet.presentation.searchevent
+
+import android.os.Bundle
+import androidx.activity.viewModels
+import com.teameetmeet.meetmeet.R
+import com.teameetmeet.meetmeet.databinding.ActivitySearchEventBinding
+import com.teameetmeet.meetmeet.presentation.base.BaseActivity
+
+class SearchActivity : BaseActivity<ActivitySearchEventBinding>(
+    R.layout.activity_search_event
+) {
+    private val viewModel: SearchEventViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        with(binding) {
+            vm = viewModel
+            lifecycleOwner = this@SearchActivity
+            searchEventSv.setupWithSearchBar(searchEventSb)
+            searchEventSpinner.setSelection(1)
+        }
+    }
+}

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/searchevent/SearchEventViewModel.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/searchevent/SearchEventViewModel.kt
@@ -1,0 +1,70 @@
+package com.teameetmeet.meetmeet.presentation.searchevent
+
+import androidx.core.util.Pair
+import androidx.lifecycle.ViewModel
+import com.teameetmeet.meetmeet.data.toDateString
+import com.teameetmeet.meetmeet.util.toEndLong
+import com.teameetmeet.meetmeet.util.toStartLong
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.time.LocalDate
+
+class SearchEventViewModel : ViewModel() {
+    private val localDate get() = LocalDate.now().atStartOfDay().toLocalDate()
+
+    private val _searchKeyword: MutableStateFlow<String> = MutableStateFlow("")
+    val searchKeyword: StateFlow<String> = _searchKeyword
+
+    private val _searchDateRange: MutableStateFlow<Pair<Long, Long>> = MutableStateFlow(Pair(0, 0))
+    val searchDateRange: StateFlow<Pair<Long, Long>> = _searchDateRange
+
+    private val _searchDateRangeText: MutableStateFlow<String> = MutableStateFlow("")
+    val searchDateRangeText: StateFlow<String> = _searchDateRangeText
+
+    val setSearchKeyword: (String) -> Unit = { keyword ->
+        _searchKeyword.update { keyword }
+    }
+
+    fun setSearchDateRange(pair: Pair<Long, Long>) {
+        _searchDateRange.update { pair }
+        _searchDateRangeText.update {
+            "${pair.first.toDateString()} ~ ${pair.second.toDateString()}"
+        }
+    }
+
+    private fun setSearchDateRangeTwoWeeks() {
+        setSearchDateRange(
+            Pair(
+                localDate.minusWeeks(1).toStartLong(),
+                localDate.plusWeeks(1).toEndLong(),
+            )
+        )
+    }
+
+    private fun setSearchDateRangeTwoMonths() {
+        setSearchDateRange(
+            Pair(
+                localDate.minusMonths(1).toStartLong(),
+                localDate.plusMonths(1).toEndLong(),
+            )
+        )
+    }
+
+    private fun setSearchDateRangeSixMonths() {
+        setSearchDateRange(
+            Pair(
+                localDate.minusMonths(3).toStartLong(),
+                localDate.plusMonths(3).toEndLong(),
+            )
+        )
+    }
+
+    fun onRangeSelected(position: Int) {
+        when (position) {
+            1 -> setSearchDateRangeTwoWeeks()
+            2 -> setSearchDateRangeTwoMonths()
+            3 -> setSearchDateRangeSixMonths()
+        }
+    }
+}

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/searchevent/SearchViewDataBinding.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/searchevent/SearchViewDataBinding.kt
@@ -1,0 +1,25 @@
+package com.teameetmeet.meetmeet.presentation.searchevent
+
+import androidx.core.widget.addTextChangedListener
+import androidx.databinding.BindingAdapter
+import com.google.android.material.search.SearchView
+
+@BindingAdapter("text_max_length")
+fun SearchView.setTextMaxLength(maxLength: Int) {
+    editText.addTextChangedListener {
+        val text = it.toString()
+        if (text.length > maxLength) {
+            editText.setText(text.substring(0, maxLength))
+            editText.setSelection(maxLength)
+        }
+    }
+}
+
+@BindingAdapter("on_submit_text")
+fun SearchView.setOnSubmitText(onSubmitText: (String) -> Unit) {
+    editText.setOnEditorActionListener { textView, _, _ ->
+        onSubmitText(textView.text.toString())
+        hide()
+        false
+    }
+}

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/util/LocalDateExtension.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/util/LocalDateExtension.kt
@@ -3,11 +3,20 @@ package com.teameetmeet.meetmeet.util
 import com.teameetmeet.meetmeet.presentation.model.CalendarItem
 import java.time.LocalDate
 import java.time.YearMonth
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 fun LocalDate.toYearMonth(): String {
     val formatter = DateTimeFormatter.ofPattern("yyyy년 MM월")
     return format(formatter)
+}
+
+fun LocalDate.toStartLong(): Long {
+    return atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+}
+
+fun LocalDate.toEndLong(): Long {
+    return plusDays(1).toStartLong() - 1
 }
 
 fun LocalDate.getDayListInMonth(calendarItem: CalendarItem? = null): List<CalendarItem> {

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/util/LongExtension.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/util/LongExtension.kt
@@ -1,0 +1,10 @@
+package com.teameetmeet.meetmeet.util
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+fun Long.toLocalDate(): LocalDate {
+    return Instant.ofEpochMilli(this).atZone(ZoneId.systemDefault()).toLocalDate()
+}
+

--- a/android/app/src/main/res/layout/activity_search_event.xml
+++ b/android/app/src/main/res/layout/activity_search_event.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="vm"
+            type="com.teameetmeet.meetmeet.presentation.searchevent.SearchEventViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/search_event_abl"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <com.google.android.material.search.SearchBar
+                android:id="@+id/search_event_sb"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/search_event_hint"
+                android:text="@{vm.searchKeyword}"
+                app:navigationIcon="@drawable/ic_nav_pre" />
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <com.google.android.material.search.SearchView
+            android:id="@+id/search_event_sv"
+            on_submit_text="@{vm.setSearchKeyword}"
+            text_max_length="@{@integer/text_length_short}"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:hint="@string/search_event_hint"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0" />
+
+        <Spinner
+            android:id="@+id/search_event_spinner"
+            android:layout_width="120dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:entries="@array/search_event_date_range"
+            android:onItemSelected="@{(p1,v,p2,i) -> vm.onRangeSelected(p2)}"
+            android:textAlignment="center"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/search_event_abl" />
+
+        <TextView
+            android:id="@+id/search_event_tv_date_range"
+            style="@style/medium"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:drawablePadding="10dp"
+            android:text="@{vm.searchDateRangeText}"
+            app:drawableStartCompat="@drawable/ic_calendar"
+            app:layout_constraintBottom_toBottomOf="@id/search_event_spinner"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/search_event_spinner"
+            app:layout_constraintTop_toTopOf="@id/search_event_spinner" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/search_event_spinner"
+            tools:listitem="@layout/item_event_simple" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/item_event_simple.xml
+++ b/android/app/src/main/res/layout/item_event_simple.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/item_event_tv_title"
+            style="@style/medium.bold"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="2"
+            app:layout_constraintEnd_toStartOf="@id/item_event_ll_date"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Title" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/item_event_rv_profiles"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/item_event_ll_date"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/item_event_tv_title"
+            tools:listitem="@layout/item_profile_pic" />
+
+        <LinearLayout
+            android:id="@+id/item_event_ll_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="end"
+            android:orientation="vertical"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                style="@style/small.bold"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="2023" />
+
+            <TextView
+                style="@style/large.bold"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="10.18" />
+
+            <TextView
+                style="@style/small.bold"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="금요일" />
+
+            <TextView
+                style="@style/caption"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="5dp"
+                tools:text="~ 2023.11.25" />
+        </LinearLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/item_profile_pic.xml
+++ b/android/app/src/main/res/layout/item_profile_pic.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="4dp"
+        app:cardCornerRadius="100dp">
+
+        <ImageView
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:backgroundTint="@color/black"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.cardview.widget.CardView>
+
+</layout>

--- a/android/app/src/main/res/values/arrays.xml
+++ b/android/app/src/main/res/values/arrays.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="search_event_date_range">
+        <item>구간</item>
+        <item>2 주</item>
+        <item>2 개월</item>
+        <item>6 개월</item>
+    </string-array>
+</resources>

--- a/android/app/src/main/res/values/integers.xml
+++ b/android/app/src/main/res/values/integers.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="text_length_short">64</integer>
+    <integer name="text_length_long">255</integer>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -46,4 +46,7 @@
     <string name="login_kakao_login_button_description">kakao login button</string>
     <string name="login_app_login">로그인</string>
     <string name="login_app_sign_up">회원가입</string>
+
+    <string name="search_event_title">일정 검색</string>
+    <string name="search_event_hint">검색어를 입력하세요</string>
 </resources>


### PR DESCRIPTION
## 개요

- 이슈번호: #34
- 한줄 설명: 일정 검색 ui 작성, 뷰모델 연결

## 설명

- material searchbar, search view로 검색창 구현
- 구간 설정하면 date picker에도 적용되도록 함

## 고민거리 

### Q. material date picker와 local date time 이 9시간 정도 차이나는데 이유를 모르겠다....
- utc 와 서울의 시간 차이가 9시간이긴 한데, 그럼 date picker의 시간이 9시간 느려야 하는 거 아닌가?? 지금은 9시간 빠른 상황이다..
- 오늘 오후 3시에 date picker의 날짜를 확인하면 진실을 알 수 있을 것,,

## 구현사진

<img height=500 src="https://github.com/boostcampwm2023/and08-meetmeet/assets/83488485/e9be8609-9e2a-459e-954d-0ce170ee7893"/>
