### PR TITLE
Feature/backend/#15 get events: 기간별 일정 조회 api

### DIFF
--- a/backend/src/common/common.entity.ts
+++ b/backend/src/common/common.entity.ts
@@ -9,12 +9,12 @@ export class commonEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @CreateDateColumn({ type: 'timestamp' })
+  @CreateDateColumn({ type: 'timestamp', select: false })
   createdAt: Date;
 
-  @UpdateDateColumn({ type: 'timestamp' })
+  @UpdateDateColumn({ type: 'timestamp', select: false })
   updatedAt: Date;
 
-  @DeleteDateColumn({ type: 'timestamp', nullable: true })
+  @DeleteDateColumn({ type: 'timestamp', nullable: true, select: false })
   deletedAt: Date | null;
 }

--- a/backend/src/event/entities/event.entity.ts
+++ b/backend/src/event/entities/event.entity.ts
@@ -24,6 +24,9 @@ export class Event extends commonEntity {
   @Column({ type: 'varchar', length: 255, nullable: true })
   announcement: string;
 
+  @Column({ nullable: true })
+  repeatPolicyId: number;
+
   @ManyToOne(() => RepeatPolicy, (repeatPolicy) => repeatPolicy.events)
   repeatPolicy: RepeatPolicy;
 

--- a/backend/src/event/entities/repeatPolicy.entity.ts
+++ b/backend/src/event/entities/repeatPolicy.entity.ts
@@ -8,7 +8,6 @@ export class RepeatPolicy extends commonEntity {
   startDate: Date;
 
   @Column('timestamp', {
-    name: 'endDate',
     default: () => "'2038-01-18 00:00:00'",
   })
   endDate: Date;

--- a/backend/src/event/event.controller.spec.ts
+++ b/backend/src/event/event.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventController } from './event.controller';
+
+describe('EventController', () => {
+  let controller: EventController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [EventController],
+    }).compile();
+
+    controller = module.get<EventController>(EventController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/event/event.controller.ts
+++ b/backend/src/event/event.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { Event } from './entities/event.entity';
+import { EventService } from './event.service';
+
+@Controller('events')
+export class EventController {
+  constructor(private readonly eventService: EventService) {}
+
+  @Get()
+  async getEvents(
+    @Query('startDate') startDate: string,
+    @Query('endDate') endDate: string,
+  ): Promise<Event[]> {
+    return await this.eventService.getEvents(startDate, endDate);
+  }
+}

--- a/backend/src/event/event.module.ts
+++ b/backend/src/event/event.module.ts
@@ -2,8 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Event } from './entities/event.entity';
 import { RepeatPolicy } from './entities/repeatPolicy.entity';
+import { EventController } from './event.controller';
+import { EventService } from './event.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Event, RepeatPolicy])],
+  controllers: [EventController],
+  providers: [EventService],
 })
 export class EventModule {}

--- a/backend/src/event/event.service.spec.ts
+++ b/backend/src/event/event.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventService } from './event.service';
+
+describe('EventService', () => {
+  let service: EventService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EventService],
+    }).compile();
+
+    service = module.get<EventService>(EventService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/event/event.service.ts
+++ b/backend/src/event/event.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Between, LessThan, MoreThan, Repository } from 'typeorm';
+import { Event } from './entities/event.entity';
+
+@Injectable()
+export class EventService {
+  constructor(
+    @InjectRepository(Event)
+    private eventRepository: Repository<Event>,
+  ) {}
+
+  async getEvents(startDate: string, endDate: string) {
+    return await this.eventRepository.find({
+      where: [
+        {
+          startDate: Between(new Date(startDate), new Date(endDate)),
+        },
+        { endDate: Between(new Date(startDate), new Date(endDate)) },
+        {
+          startDate: LessThan(new Date(startDate)),
+          endDate: MoreThan(new Date(endDate)),
+        },
+      ],
+    });
+  }
+}

--- a/backend/src/user/entities/user.entity.ts
+++ b/backend/src/user/entities/user.entity.ts
@@ -8,7 +8,7 @@ export class User extends commonEntity {
   @Column({ type: 'varchar', length: 255, unique: true })
   email: string;
 
-  @Column({ type: 'varchar', length: 255 })
+  @Column({ type: 'varchar', length: 255, select: false })
   password: string;
 
   @Column({ type: 'varchar', length: 64, unique: true })


### PR DESCRIPTION
## 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

issue: #15 
startDate와 endDate를 입력받아 일정을 조회하는 api 구현

## 설명

<!-- 

- 현재 Pr 설명 

-->

`GET /events?startDate=&endDate=`
요청을 받아 그 사이에 포함된 일정들을 모두 반환하도록 했습니다.

- Response 예시

<img width="801" alt="image" src="https://github.com/boostcampwm2023/and08-meetmeet/assets/79151181/458494e8-499d-4826-93f4-cfb11948719d">

API 명세에는 `eventMember`와 `authority`가 포함되어있지만 현재 구현되지 않은 기능들이라 제외했습니다..!

## 고민거리 

<!-- (Optional) 의견 받고싶은 부분 있으면 적어두기

### Q. ui 이벤트 처리를 어디서 해야할 지 모르겠어요...

-->

query string으로 들어온 startDate에서의 시간은 17:14:32인데 쿼리에 들어간 시간은 08:14:32이다.. UTC....