### PR TITLE
Feature/backend/#43 kakao login: 카카오 로그인 API 구현

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiBody, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { User } from 'src/user/entities/user.entity';
 import { AuthService } from './auth.service';
 import { AuthUserDto } from './dto/auth-user.dto';
@@ -12,26 +12,56 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('register')
+  @ApiOperation({
+    summary: 'email, password 회원가입 API',
+  })
   register(@Body() authUserDto: AuthUserDto) {
     return this.authService.register(authUserDto);
   }
 
-  @ApiBody({
-    description: 'post swagger',
-    type: AuthUserDto,
+  @Post('kakao')
+  @ApiOperation({
+    summary: '카카오 로그인 API',
   })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        kakaoId: {
+          type: 'string',
+          description: '카카오 API를 통해 받은 유저 정보 (닉네임)',
+        },
+      },
+    },
+  })
+  kakaoLogin(@Body('kakaoId') kakaoId: string) {
+    return this.authService.kakaoLogin(kakaoId);
+  }
+
   @UseGuards(AuthGuard('local'))
   @Post('login')
-  login(@GetUser() user: User) {
+  @ApiOperation({
+    summary: 'email, password 로그인 API',
+  })
+  @ApiBody({
+    type: AuthUserDto,
+  })
+  localLogin(@GetUser() user: User) {
     return this.authService.login(user);
   }
 
   @Get('check/email')
+  @ApiOperation({
+    summary: 'email 중복 확인 API',
+  })
   checkEmail(@Query('email') email: string) {
     return this.authService.checkEmail(email);
   }
 
   @Get('check/nickname')
+  @ApiOperation({
+    summary: 'nickname 중복 확인 API',
+  })
   checkNickname(@Query('nickname') nickname: string) {
     return this.authService.checkNickname(nickname);
   }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,10 +1,11 @@
 import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { User } from 'src/user/entities/user.entity';
 import { AuthService } from './auth.service';
 import { AuthUserDto } from './dto/auth-user.dto';
 import { GetUser } from './get-user.decorator';
+import { JwtAuthGuard } from './jwt-auth.guard';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -48,6 +49,19 @@ export class AuthController {
   })
   localLogin(@GetUser() user: User) {
     return this.authService.login(user);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('refresh')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    summary: 'access token 갱신 API',
+  })
+  async refresh(
+    @GetUser() user: User,
+    @Body('refreshToken') refreshToken: string,
+  ) {
+    return this.authService.refresh(user, refreshToken);
   }
 
   @Get('check/email')

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiBody, ApiTags } from '@nestjs/swagger';
 import { User } from 'src/user/entities/user.entity';
@@ -24,5 +24,15 @@ export class AuthController {
   @Post('login')
   login(@GetUser() user: User) {
     return this.authService.login(user);
+  }
+
+  @Get('check/email')
+  checkEmail(@Query('email') email: string) {
+    return this.authService.checkEmail(email);
+  }
+
+  @Get('check/nickname')
+  checkNickname(@Query('nickname') nickname: string) {
+    return this.authService.checkNickname(nickname);
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -39,6 +39,23 @@ export class AuthService {
     return user;
   }
 
+  async kakaoLogin(kakaoId: string) {
+    const user = await this.userService.findUserByOAuth(kakaoId, 'kakao');
+
+    if (user) {
+      return this.login(user);
+    }
+
+    const nickname = uuidv4().split('-').at(0)!;
+    const createdUser = await this.userService.oauthCreateUser(
+      kakaoId,
+      nickname,
+      'kakao',
+    );
+
+    return this.login(createdUser);
+  }
+
   async login(user: User) {
     return {
       accessToken: await this.jwtService.signAsync({

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -59,4 +59,20 @@ export class AuthService {
       },
     );
   }
+
+  async checkEmail(email: string) {
+    const user = await this.userService.findUserByEmail(email);
+
+    return {
+      isAvailable: user ? false : true,
+    };
+  }
+
+  async checkNickname(nickname: string) {
+    const user = await this.userService.findUserByNickname(nickname);
+
+    return {
+      isAvailable: user ? false : true,
+    };
+  }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -10,7 +10,15 @@ async function bootstrap() {
     .setTitle(`MeetMeet's backend api`)
     .setDescription(`The MeetMeet's API description`)
     .setVersion('1.0')
-    .addTag('cats')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        name: 'JWT',
+        in: 'header',
+      },
+      'access-token',
+    )
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('docs', app, document);

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,8 +1,9 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { hash } from 'bcrypt';
 import { User } from './entities/user.entity';
+import { OauthProvider } from './entities/oauthProvider.entity';
 
 const SALTROUND = 10;
 
@@ -10,6 +11,8 @@ const SALTROUND = 10;
 export class UserService {
   constructor(
     @InjectRepository(User) private userRepository: Repository<User>,
+    @InjectRepository(OauthProvider)
+    private oauthProviderRepository: Repository<OauthProvider>,
   ) {}
 
   async localCreateUser(email: string, password: string, nickname: string) {
@@ -22,6 +25,37 @@ export class UserService {
     });
 
     return await this.userRepository.save(user);
+  }
+
+  async oauthCreateUser(email: string, nickname: string, oauth: string) {
+    const hashedPassword = await hash(oauth + email, SALTROUND);
+    const oauthProvider = await this.oauthProviderRepository.findOne({
+      where: { displayName: oauth },
+    });
+
+    if (!oauthProvider) {
+      throw new BadRequestException();
+    }
+
+    const user = this.userRepository.create({
+      email: email,
+      password: hashedPassword,
+      nickname: nickname,
+    });
+    user.oauthProvider = oauthProvider;
+
+    return await this.userRepository.save(user);
+  }
+
+  async findUserByOAuth(email: string, oauthProvider: string) {
+    const result = await this.userRepository
+      .createQueryBuilder('user')
+      .leftJoinAndSelect('user.oauthProvider', 'oauth')
+      .where('oauth.displayName = :oauth', { oauth: oauthProvider })
+      .andWhere('user.email = :email', { email: email })
+      .getOne();
+
+    return result;
   }
 
   async findUserByEmail(email: string) {


### PR DESCRIPTION
## 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

Issue: #43 
카카오 로그인 구현
access token 갱신 API 구현 (자동 로그인)

## 설명

<!-- 

- 현재 Pr 설명 

-->

일단 카카오 회원 정보를 받아 유저 테이블에 존재하면 로그인(access token, refresh token 발급), 존재하지 않으면 회원가입 후 로그인 하도록 처리했습니다.

- #105 에서 빠졌던 refresh token 추가
- swagger Access Token 설정 추가

- Request 예시
```
POST /auth/kakao

{
  "kakaoId": "kakaoTest"
}
```

- Response 예시
```
{
  "accessToken": "access_token",
  "refreshToken": "refresh_token"
}
```

### 닉네임, 이메일 중복 확인 API 추가

- Request 예시
```
GET /auth/check/email?email=
```

- Response 예시
```
{
  "isAvailable": false
}
```

### Access token 갱신

- Request 예시
```
POST /auth/refresh
Authrization: Bearer [accessToken]

{
  "refreshToken": "refreshToken"
}
```

- Response 예시
```
{
  "accessToken": "access_token",
}
```

## 고민거리 

<!-- (Optional) 의견 받고싶은 부분 있으면 적어두기

### Q. ui 이벤트 처리를 어디서 해야할 지 모르겠어요...

-->

- 카카오 회원 정보를 클라이언트에서 직접적으로 받아도 될까..?
- access token을 갱신할 때 refresh token도 새로 발급해야 할까?
- swagger에서 authorization header를 사용하려면 `@ApiBearerAuth()`을 해줘야 한다...