### PR TITLE
[Feature/backend/#28 create event] API 일정 조회, 삭제, 생성 추가

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,12 +1,14 @@
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiBody, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiBody, ApiTags } from '@nestjs/swagger';
 import { User } from 'src/user/entities/user.entity';
 import { AuthService } from './auth.service';
 import { AuthUserDto } from './dto/auth-user.dto';
 import { GetUser } from './get-user.decorator';
+import { JwtAuthGuard } from './jwt-auth.guard';
 
 @ApiTags('auth')
+@ApiBearerAuth()
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
@@ -24,5 +26,18 @@ export class AuthController {
   @Post('login')
   login(@GetUser() user: User) {
     return this.authService.login(user);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('refresh')
+  refresh(@GetUser() user: User) {
+    return this.authService.refresh(user);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('test')
+  test(@GetUser() user: User, @Body() start: Date) {
+    console.log(user, start);
+    return user;
   }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -15,9 +15,6 @@ import { LocalStrategy } from './local.strategy';
     JwtModule.registerAsync({
       useFactory: async (configService: ConfigService) => ({
         secret: configService.get('JWT_SECRET_KEY'),
-        signOptions: {
-          expiresIn: '60s',
-        },
       }),
       inject: [ConfigService],
     }),

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -24,7 +24,7 @@ export class AuthService {
     const nickname = uuidv4().split('-').at(0)!;
     // TODO: nickname 중복 확인
 
-    this.userService.localCreateUser(email, password, nickname);
+    await this.userService.localCreateUser(email, password, nickname);
   }
 
   async validateUser(email: string, password: string) {
@@ -39,9 +39,35 @@ export class AuthService {
 
   async login(user: User) {
     return {
-      accessToken: await this.jwtService.signAsync({
-        nickname: user.nickname,
-      }),
+      accessToken: await this.jwtService.signAsync(
+        {
+          nickname: user.nickname,
+        },
+        { expiresIn: '5m' },
+      ),
+      refreshToken: await this.jwtService.signAsync(
+        {
+          nickname: user.nickname,
+        },
+        { expiresIn: '7d' },
+      ),
+    };
+  }
+
+  async refresh(user: User) {
+    return {
+      accessToken: await this.jwtService.signAsync(
+        {
+          nickname: user.nickname,
+        },
+        { expiresIn: '5m' },
+      ),
+      refreshToken: await this.jwtService.signAsync(
+        {
+          nickname: user.nickname,
+        },
+        { expiresIn: '7d' },
+      ),
     };
   }
 }

--- a/backend/src/calendar/calendar.module.ts
+++ b/backend/src/calendar/calendar.module.ts
@@ -8,5 +8,6 @@ import { CalendarService } from './calendar.service';
   imports: [TypeOrmModule.forFeature([Calendar])],
   controllers: [CalendarController],
   providers: [CalendarService],
+  exports: [CalendarService],
 })
 export class CalendarModule {}

--- a/backend/src/calendar/calendar.service.ts
+++ b/backend/src/calendar/calendar.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Calendar } from './entities/calendar.entity';
+import { User } from '../user/entities/user.entity';
 
 @Injectable()
 export class CalendarService {
@@ -12,5 +13,23 @@ export class CalendarService {
 
   findAll(): Promise<Calendar[]> {
     return this.calendarRepository.find();
+  }
+
+  createCalendar(user: User): Promise<Calendar> {
+    const calendar = new Calendar();
+    calendar.user = user;
+    return this.calendarRepository.save(calendar);
+  }
+
+  async getCalendarByUserId(userId: number): Promise<Calendar> {
+    const calendar = await this.calendarRepository.findOne({
+      where: { user: { id: userId } },
+    });
+
+    if (!calendar) {
+      return await this.createCalendar({ id: userId } as User);
+    }
+
+    return calendar;
   }
 }

--- a/backend/src/detail/detail.module.ts
+++ b/backend/src/detail/detail.module.ts
@@ -1,4 +1,11 @@
 import { Module } from '@nestjs/common';
+import { DetailService } from './detail.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Detail } from './entities/detail.entity';
 
-@Module({})
+@Module({
+  imports: [TypeOrmModule.forFeature([Detail])],
+  providers: [DetailService],
+  exports: [DetailService],
+})
 export class DetailModule {}

--- a/backend/src/detail/detail.service.ts
+++ b/backend/src/detail/detail.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { Detail } from './entities/detail.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CreateScheduleDto } from '../event/dto/createSchedule.dto';
+
+@Injectable()
+export class DetailService {
+  constructor(
+    @InjectRepository(Detail)
+    private detailRepository: Repository<Detail>,
+  ) {}
+
+  async createDetail(createScheduleDto: CreateScheduleDto) {
+    const detail = this.detailRepository.create({
+      ...createScheduleDto,
+    });
+    return await this.detailRepository.save(detail);
+  }
+}

--- a/backend/src/detail/detail.service.ts
+++ b/backend/src/detail/detail.service.ts
@@ -17,4 +17,15 @@ export class DetailService {
     });
     return await this.detailRepository.save(detail);
   }
+
+  async createDetailBulk(createScheduleDto: CreateScheduleDto, count: number) {
+    const detailArray = [];
+    for (let i = 0; i < count; i++) {
+      const detail = this.detailRepository.create({
+        ...createScheduleDto,
+      });
+      detailArray.push(detail);
+    }
+    return await this.detailRepository.save(detailArray);
+  }
 }

--- a/backend/src/event-member/entities/authority.entity.ts
+++ b/backend/src/event-member/entities/authority.entity.ts
@@ -1,8 +1,9 @@
 import { Column, Entity } from 'typeorm';
 import { commonEntity } from 'src/common/common.entity';
+import { AuthorityEnum } from './authority.enum';
 
 @Entity()
 export class Authority extends commonEntity {
-  @Column({ type: 'varchar', length: 255 })
+  @Column({ type: 'enum', enum: AuthorityEnum, default: AuthorityEnum.MEMBER })
   displayName: string;
 }

--- a/backend/src/event-member/entities/authority.enum.ts
+++ b/backend/src/event-member/entities/authority.enum.ts
@@ -1,0 +1,6 @@
+export enum AuthorityEnum {
+  OWNER = 'OWNER',
+  ADMIN = 'ADMIN',
+  MEMBER = 'MEMBER',
+  GUEST = 'GUEST',
+}

--- a/backend/src/event-member/entities/eventMember.entity.ts
+++ b/backend/src/event-member/entities/eventMember.entity.ts
@@ -3,7 +3,7 @@ import { commonEntity } from 'src/common/common.entity';
 import { Detail } from 'src/detail/entities/detail.entity';
 import { Event } from 'src/event/entities/event.entity';
 import { User } from 'src/user/entities/user.entity';
-import { Authority } from './autority.entity';
+import { Authority } from './authority.entity';
 
 @Entity()
 export class EventMember extends commonEntity {

--- a/backend/src/event-member/event-member.module.ts
+++ b/backend/src/event-member/event-member.module.ts
@@ -1,6 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { EventMember } from './entities/eventMember.entity';
+import { Authority } from './entities/authority.entity';
+import { EventMemberService } from './event-memer.service';
 
-@Module({ imports: [TypeOrmModule.forFeature([EventMember])] })
+@Module({
+  imports: [TypeOrmModule.forFeature([EventMember, Authority])],
+  providers: [EventMemberService],
+  exports: [EventMemberService],
+})
 export class EventMemberModule {}

--- a/backend/src/event-member/event-memer.service.ts
+++ b/backend/src/event-member/event-memer.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { EventMember } from './entities/eventMember.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Between, Repository } from 'typeorm';
+import { User } from '../user/entities/user.entity';
+import { Detail } from '../detail/entities/detail.entity';
+import { Authority } from './entities/authority.entity';
+import { Event } from '../event/entities/event.entity';
+
+@Injectable()
+export class EventMemberService {
+  constructor(
+    @InjectRepository(EventMember)
+    private eventMemberRepository: Repository<EventMember>,
+    @InjectRepository(Authority)
+    private authorityRepository: Repository<Authority>,
+  ) {}
+
+  async getAuthorityId(displayName: string) {
+    return await this.authorityRepository.findOneBy({
+      displayName: displayName,
+    });
+  }
+
+  async getEventByUser(user: User, startDate: Date, endDate: Date) {
+    if (!user) return null;
+    const eventMembers = await this.eventMemberRepository.find({
+      relations: ['event'],
+      where: {
+        user: { id: user.id },
+        event: { startDate: Between(startDate, endDate) },
+      },
+    });
+    return eventMembers.map((eventMember) => eventMember.event);
+  }
+
+  async createEventMember(
+    event: Event,
+    user: User,
+    detail: Detail,
+    authority: Authority,
+  ): Promise<void> {
+    const eventMember = this.eventMemberRepository.create({
+      user: user,
+      detail: detail,
+      authority: authority,
+      event: event,
+    });
+    await this.eventMemberRepository.save(eventMember);
+  }
+}

--- a/backend/src/event-member/event-memer.service.ts
+++ b/backend/src/event-member/event-memer.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { EventMember } from './entities/eventMember.entity';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Between, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { User } from '../user/entities/user.entity';
 import { Detail } from '../detail/entities/detail.entity';
 import { Authority } from './entities/authority.entity';
@@ -35,5 +35,24 @@ export class EventMemberService {
       event: event,
     });
     await this.eventMemberRepository.save(eventMember);
+  }
+
+  async createEventMemberBulk(
+    events: Event[],
+    user: User,
+    details: Detail[],
+    authority: Authority,
+  ) {
+    const eventMembers = [];
+    for (let i = 0; i < events.length; i++) {
+      eventMembers.push({
+        user: user,
+        detail: details[i],
+        authority: authority,
+        event: events[i],
+      });
+    }
+    console.log(eventMembers);
+    await this.eventMemberRepository.save(eventMembers);
   }
 }

--- a/backend/src/event-member/event-memer.service.ts
+++ b/backend/src/event-member/event-memer.service.ts
@@ -22,18 +22,6 @@ export class EventMemberService {
     });
   }
 
-  async getEventByUser(user: User, startDate: Date, endDate: Date) {
-    if (!user) return null;
-    const eventMembers = await this.eventMemberRepository.find({
-      relations: ['event'],
-      where: {
-        user: { id: user.id },
-        event: { startDate: Between(startDate, endDate) },
-      },
-    });
-    return eventMembers.map((eventMember) => eventMember.event);
-  }
-
   async createEventMember(
     event: Event,
     user: User,

--- a/backend/src/event/dto/createSchedule.dto.ts
+++ b/backend/src/event/dto/createSchedule.dto.ts
@@ -1,0 +1,48 @@
+import {
+  IsBoolean,
+  IsDateString,
+  IsEnum,
+  IsOptional,
+  IsString,
+  Length,
+} from 'class-validator';
+
+enum RepeatTerm {
+  DAY = 'DAY',
+  WEEK = 'WEEK',
+  MONTH = 'MONTH',
+  YEAR = 'YEAR',
+}
+export class CreateScheduleDto {
+  @IsString()
+  @Length(1, 64)
+  title: string;
+
+  @IsDateString()
+  startDate: string;
+
+  @IsDateString()
+  endDate: string;
+
+  @IsBoolean()
+  isJoinable: boolean;
+
+  @IsBoolean()
+  isVisible: boolean;
+
+  @IsOptional()
+  @IsString()
+  @Length(1, 64)
+  memo?: string;
+
+  @IsOptional()
+  @IsEnum(RepeatTerm)
+  repeatTerm?: RepeatTerm;
+
+  @IsOptional()
+  repeatFrequency?: number;
+
+  @IsOptional()
+  @IsDateString()
+  repeatEndDate?: string;
+}

--- a/backend/src/event/dto/createSchedule.dto.ts
+++ b/backend/src/event/dto/createSchedule.dto.ts
@@ -7,7 +7,7 @@ import {
   Length,
 } from 'class-validator';
 
-enum RepeatTerm {
+export enum RepeatTerm {
   DAY = 'DAY',
   WEEK = 'WEEK',
   MONTH = 'MONTH',
@@ -44,5 +44,5 @@ export class CreateScheduleDto {
 
   @IsOptional()
   @IsDateString()
-  repeatEndDate?: string;
+  repeatEndDate?: Date;
 }

--- a/backend/src/event/event.controller.ts
+++ b/backend/src/event/event.controller.ts
@@ -27,7 +27,7 @@ export class EventController {
     @GetUser() user: User,
     @Query('startDate') startDate: string,
     @Query('endDate') endDate: string,
-  ): Promise<{ events: Event[] }> {
+  ) {
     return await this.eventService.getEvents(user, startDate, endDate);
   }
 

--- a/backend/src/event/event.controller.ts
+++ b/backend/src/event/event.controller.ts
@@ -8,7 +8,6 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
-import { Event } from './entities/event.entity';
 import { EventService } from './event.service';
 import { GetUser } from '../auth/get-user.decorator';
 import { User } from '../user/entities/user.entity';

--- a/backend/src/event/event.controller.ts
+++ b/backend/src/event/event.controller.ts
@@ -1,8 +1,13 @@
-import { Controller, Get, Query } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { Event } from './entities/event.entity';
 import { EventService } from './event.service';
+import { GetUser } from '../auth/get-user.decorator';
+import { User } from '../user/entities/user.entity';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CreateScheduleDto } from './dto/createSchedule.dto';
 
+@ApiBearerAuth()
 @ApiTags('event')
 @Controller('event')
 export class EventController {
@@ -14,5 +19,14 @@ export class EventController {
     @Query('endDate') endDate: string,
   ): Promise<Event[]> {
     return await this.eventService.getEvents(startDate, endDate);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('')
+  async createEvent(
+    @GetUser() user: User,
+    @Body() createScheduleDto: CreateScheduleDto,
+  ) {
+    return await this.eventService.createEvent(user, createScheduleDto);
   }
 }

--- a/backend/src/event/event.controller.ts
+++ b/backend/src/event/event.controller.ts
@@ -1,8 +1,11 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
+  Param,
+  ParseIntPipe,
   Post,
   Query,
   UseGuards,
@@ -38,5 +41,16 @@ export class EventController {
     @Body() createScheduleDto: CreateScheduleDto,
   ) {
     return await this.eventService.createEvent(user, createScheduleDto);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete('/:eventId')
+  async deleteEvent(
+    @GetUser() user: User,
+    @Param('eventId', new ParseIntPipe({ errorHttpStatusCode: 400 }))
+    eventId: number,
+  ) {
+    console.log(eventId);
+    return await this.eventService.deleteEvent(user, eventId);
   }
 }

--- a/backend/src/event/event.controller.ts
+++ b/backend/src/event/event.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { Event } from './entities/event.entity';
 import { EventService } from './event.service';
@@ -13,15 +21,18 @@ import { CreateScheduleDto } from './dto/createSchedule.dto';
 export class EventController {
   constructor(private readonly eventService: EventService) {}
 
+  @UseGuards(JwtAuthGuard)
   @Get()
   async getEvents(
+    @GetUser() user: User,
     @Query('startDate') startDate: string,
     @Query('endDate') endDate: string,
-  ): Promise<Event[]> {
-    return await this.eventService.getEvents(startDate, endDate);
+  ): Promise<{ events: Event[] }> {
+    return await this.eventService.getEvents(user, startDate, endDate);
   }
 
   @UseGuards(JwtAuthGuard)
+  @HttpCode(201)
   @Post('')
   async createEvent(
     @GetUser() user: User,

--- a/backend/src/event/event.module.ts
+++ b/backend/src/event/event.module.ts
@@ -7,13 +7,25 @@ import { EventService } from './event.service';
 import { CalendarModule } from '../calendar/calendar.module';
 import { CalendarService } from '../calendar/calendar.service';
 import { Calendar } from '../calendar/entities/calendar.entity';
+import { DetailService } from '../detail/detail.service';
+import { Detail } from '../detail/entities/detail.entity';
+import { Authority } from '../event-member/entities/authority.entity';
+import { EventMemberService } from '../event-member/event-memer.service';
+import { EventMember } from '../event-member/entities/eventMember.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Event, RepeatPolicy, Calendar]),
+    TypeOrmModule.forFeature([
+      Event,
+      RepeatPolicy,
+      Calendar,
+      Detail,
+      Authority,
+      EventMember,
+    ]),
     CalendarModule,
   ],
   controllers: [EventController],
-  providers: [EventService, CalendarService],
+  providers: [EventService, CalendarService, DetailService, EventMemberService],
 })
 export class EventModule {}

--- a/backend/src/event/event.module.ts
+++ b/backend/src/event/event.module.ts
@@ -4,10 +4,16 @@ import { Event } from './entities/event.entity';
 import { RepeatPolicy } from './entities/repeatPolicy.entity';
 import { EventController } from './event.controller';
 import { EventService } from './event.service';
+import { CalendarModule } from '../calendar/calendar.module';
+import { CalendarService } from '../calendar/calendar.service';
+import { Calendar } from '../calendar/entities/calendar.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Event, RepeatPolicy])],
+  imports: [
+    TypeOrmModule.forFeature([Event, RepeatPolicy, Calendar]),
+    CalendarModule,
+  ],
   controllers: [EventController],
-  providers: [EventService],
+  providers: [EventService, CalendarService],
 })
 export class EventModule {}

--- a/backend/src/event/event.service.ts
+++ b/backend/src/event/event.service.ts
@@ -2,12 +2,16 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Between, LessThan, MoreThan, Repository } from 'typeorm';
 import { Event } from './entities/event.entity';
+import { User } from '../user/entities/user.entity';
+import { CreateScheduleDto } from './dto/createSchedule.dto';
+import { CalendarService } from '../calendar/calendar.service';
 
 @Injectable()
 export class EventService {
   constructor(
     @InjectRepository(Event)
     private eventRepository: Repository<Event>,
+    private calendarService: CalendarService,
   ) {}
 
   async getEvents(startDate: string, endDate: string) {
@@ -23,5 +27,16 @@ export class EventService {
         },
       ],
     });
+  }
+
+  async createEvent(user: User, createScheduleDto: CreateScheduleDto) {
+    // todo: calendar 어떻게 처리할지 의논
+    const calendar = await this.calendarService.getCalendarByUserId(user.id);
+    const event = this.eventRepository.create({
+      ...createScheduleDto,
+      calendar,
+    });
+    console.log(event);
+    return await this.eventRepository.save(event);
   }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -9,8 +9,13 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle(`MeetMeet's backend api`)
     .setDescription(`The MeetMeet's API description`)
+    .addBearerAuth({
+      type: 'http',
+      scheme: 'bearer',
+      name: 'JWT',
+      in: 'header',
+    })
     .setVersion('1.0')
-    .addTag('cats')
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('docs', app, document);

--- a/backend/src/user/entities/userGroup.entity.ts
+++ b/backend/src/user/entities/userGroup.entity.ts
@@ -1,5 +1,5 @@
 import { Entity, ManyToOne, PrimaryColumn } from 'typeorm';
-import { Authority } from 'src/event-member/entities/autority.entity';
+import { Authority } from 'src/event-member/entities/authority.entity';
 import { Group } from 'src/group/entities/group.entity';
 import { User } from './user.entity';
 


### PR DESCRIPTION
## 개요

일정 생성, 조회, 삭제에 관한 기본 api 를 생성하였습니다.


## 설명

- 조회 : 구간을 받아 그 기간의 데이터를 뽑아서 처리하도록 구성하였습니다.
- 생성 : 반복되는 일정도 생성되도록 구성하였습니다.
- 삭제 : 기본적인 삭제 로직이 구성하였지만, 추후 코드를 더 작성해야합니다.

## 고민거리 

### Q. 예외처리에 대한 케이스
- 예외처리를 미처 하지 못한 케이스가 많습니다. null 일때 조건을 걸어 조회하지 못하게 하는 등의 처리가 필요할 것 같습니다.
