### PR TITLE
Feature/backend/#55 #56 update user: 이미지 업로드 및 회원 정보 조회 API

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -14,6 +14,7 @@ import { GroupModule } from './group/group.module';
 import { FollowModule } from './follow/follow.module';
 import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
+import { ContentModule } from './content/content.module';
 
 @Module({
   imports: [
@@ -44,6 +45,7 @@ import { UserModule } from './user/user.module';
     FollowModule,
     UserModule,
     AuthModule,
+    ContentModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -75,6 +75,14 @@ export class AuthController {
     return this.authService.refresh(user, refreshToken);
   }
 
+  @Get('check/token')
+  @ApiOperation({
+    summary: 'access token 검증 API',
+  })
+  checkAccessToken(@Query('token') token: string) {
+    return this.authService.verifyToken(token);
+  }
+
   @Get('check/email')
   @ApiOperation({
     summary: 'email 중복 확인 API',

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -57,6 +57,17 @@ export class AuthController {
   @ApiOperation({
     summary: 'access token 갱신 API',
   })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        refreshToken: {
+          type: 'string',
+          description: '새로운 access token 발급을 위한 refresh token',
+        },
+      },
+    },
+  })
   async refresh(
     @GetUser() user: User,
     @Body('refreshToken') refreshToken: string,

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -101,6 +101,21 @@ export class AuthService {
     );
   }
 
+  async verifyToken(token: string) {
+    try {
+      const payload = this.jwtService.verify(token, {
+        secret: this.configService.get<string>('JWT_SECRET_KEY'),
+      });
+      return {
+        isVerified: !this.isExpired(payload.exp),
+      };
+    } catch (err) {
+      return {
+        isVerified: false,
+      };
+    }
+  }
+
   async checkEmail(email: string) {
     const user = await this.userService.findUserByEmail(email);
 
@@ -115,5 +130,9 @@ export class AuthService {
     return {
       isAvailable: user ? false : true,
     };
+  }
+
+  isExpired(exp: number) {
+    return exp < new Date().getTime() / 1000;
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -77,7 +77,10 @@ export class AuthService {
       throw new UnauthorizedException('Invalid User');
     }
 
-    return { accessToken: await this.generateAccessToken(user) };
+    return {
+      accessToken: await this.generateAccessToken(user),
+      refreshToken: await this.generateRefreshToken(user),
+    };
   }
 
   async generateAccessToken(user: User): Promise<string> {

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -12,8 +12,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     private configService: ConfigService,
   ) {
     super({
-      // todo : ignoreExpiration true로 바꿀지 고민
-      ignoreExpiration: false,
+      ignoreExpiration: true,
       secretOrKey: configService.get('JWT_SECRET_KEY'),
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
     });

--- a/backend/src/common/config/multer.config.ts
+++ b/backend/src/common/config/multer.config.ts
@@ -1,0 +1,26 @@
+import * as fs from 'fs';
+import { diskStorage } from 'multer';
+import { extname } from 'path';
+import { v4 as uuidv4 } from 'uuid';
+
+export const multerOptions = {
+  storage: diskStorage({
+    destination: (req, file, callback) => {
+      const filePath: string = 'uploads';
+
+      if (!fs.existsSync(filePath)) {
+        fs.mkdirSync(filePath, { recursive: true });
+      }
+
+      callback(null, filePath);
+    },
+
+    filename: (req, file, callback) => {
+      callback(null, generateRandomFileName(file));
+    },
+  }),
+};
+
+const generateRandomFileName = (file: Express.Multer.File) => {
+  return `${uuidv4()}${extname(file.originalname)}`;
+};

--- a/backend/src/common/config/multer.config.ts
+++ b/backend/src/common/config/multer.config.ts
@@ -9,7 +9,7 @@ export const multerOptions = {
       const filePath: string = 'uploads';
 
       if (!fs.existsSync(filePath)) {
-        fs.mkdirSync(filePath, { recursive: true });
+        fs.mkdirSync(filePath);
       }
 
       callback(null, filePath);

--- a/backend/src/content/content.controller.ts
+++ b/backend/src/content/content.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('content')
+export class ContentController {}

--- a/backend/src/content/content.module.ts
+++ b/backend/src/content/content.module.ts
@@ -1,4 +1,13 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ContentController } from './content.controller';
+import { ContentService } from './content.service';
+import { Content } from './entities/content.entity';
 
-@Module({})
+@Module({
+  imports: [TypeOrmModule.forFeature([Content])],
+  controllers: [ContentController],
+  providers: [ContentService],
+  exports: [ContentService],
+})
 export class ContentModule {}

--- a/backend/src/content/content.service.ts
+++ b/backend/src/content/content.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Content } from './entities/content.entity';
+
+@Injectable()
+export class ContentService {
+  constructor(
+    @InjectRepository(Content) private contentRepository: Repository<Content>,
+  ) {}
+
+  async createContent(file: Express.Multer.File) {
+    const content = this.contentRepository.create({
+      mimeType: file.mimetype,
+      path: file.filename,
+      type: file.mimetype.split('/').at(0),
+    });
+
+    return await this.contentRepository.save(content);
+  }
+
+  async updateContent(id: number, file: Express.Multer.File) {
+    const updatedContent = this.contentRepository.create({
+      mimeType: file.mimetype,
+      path: file.filename,
+      type: file.mimetype.split('/').at(0),
+    });
+
+    await this.contentRepository.update(id, updatedContent);
+    return await this.contentRepository.findOne({ where: { id } });
+  }
+}

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -17,6 +17,7 @@ import {
 } from '@nestjs/swagger';
 import { GetUser } from 'src/auth/get-user.decorator';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { multerOptions } from 'src/common/config/multer.config';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { User } from './entities/user.entity';
 import { UserService } from './user.service';
@@ -28,12 +29,11 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @UseGuards(JwtAuthGuard)
-  @UseInterceptors(FileInterceptor('profile', { dest: './uploads/' }))
+  @UseInterceptors(FileInterceptor('profile', multerOptions))
   @Patch(':id/info')
   @ApiOperation({
     summary: '사용자 프로필, 계정 수정 API',
-    description:
-      'multipart/form-data 형식\nparameter의 id와 access token의 user id가 같아야 합니다.',
+    description: 'parameter의 id와 access token의 user id가 같아야 합니다.',
   })
   @ApiConsumes('multipart/form-data')
   updateUserInfo(

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Delete,
+  Get,
   Param,
   Patch,
   UploadedFile,
@@ -27,6 +28,16 @@ import { UserService } from './user.service';
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Get('info')
+  @ApiOperation({
+    summary: '사용자 프로필 조회 API',
+    description: 'kakao 회원의 경우 email에 kakao라고 조회됩니다.',
+  })
+  getUserInfo(@GetUser() user: User) {
+    return this.userService.getUserInfo(user);
+  }
 
   @UseGuards(JwtAuthGuard)
   @UseInterceptors(FileInterceptor('profile', multerOptions))

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,13 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Content } from 'src/content/entities/content.entity';
 import { OauthProvider } from './entities/oauthProvider.entity';
 import { User } from './entities/user.entity';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
+import { ContentModule } from 'src/content/content.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, OauthProvider, Content])],
+  imports: [TypeOrmModule.forFeature([User, OauthProvider]), ContentModule],
   providers: [UserService],
   controllers: [UserController],
   exports: [UserService],

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -55,6 +55,29 @@ export class UserService {
     return await this.userRepository.save(user);
   }
 
+  async getUserInfo(user: User) {
+    const result = await this.userRepository
+      .createQueryBuilder('user')
+      .select([
+        'user.email',
+        'user.nickname',
+        'profile.path',
+        'oauth.displayName',
+      ])
+      .leftJoin('user.profile', 'profile')
+      .leftJoin('user.oauthProvider', 'oauth')
+      .where('user.id = :id', { id: user.id })
+      .getOne();
+
+    const userInfo = {
+      email: result?.oauthProvider?.displayName ?? result?.email,
+      nickname: result?.nickname,
+      profileUrl: result?.profile?.path ?? null,
+    };
+
+    return userInfo;
+  }
+
   async updateUser(
     id: number,
     user: User,
@@ -76,7 +99,7 @@ export class UserService {
 
       user.profile = userProfile;
     }
-    console.log('profile', user.profile);
+
     await this.userRepository.update(id, {
       ...updateUserDto,
       profileId: user.profile?.id ?? null,


### PR DESCRIPTION
## 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

Issue: #55 , #56

- 사용자 프로필 사진 업로드
- 회원 정보 조회

## 설명

<!-- 

- 현재 Pr 설명 

-->

```
GET /user/info
Authorization: Bearer [access_token]
```

```
{
    "email": "user3@example.com",
    "nickname": "nickname1",
    "profileUrl": "ff943cc6-fd55-4aba-a53a-ff418634e846.jpeg"
}
```

- 만약 카카오 회원일 경우에는 email에 'kakao'를 담고, profile 사진이 없는 경우에는 profileUrl에 null이 들어갑니다!
- 업로드된 사진, 영상은 `/backend/uploads` 에 저장됩니다.

## 고민거리 

<!-- (Optional) 의견 받고싶은 부분 있으면 적어두기

### Q. ui 이벤트 처리를 어디서 해야할 지 모르겠어요...

-->

이전에 회원 정보를 수정할 때 `PATCH /user/:id/info`와 같이 user Id를 parameter로 받아서 access token과 비교 후 사용했는데 user Id를 parameter에 받을 필요가 있을까요?

여러 사용자들로부터 프로필 사진이나 피드의 사진, 영상들을 받아 서버에서 업로드하면 부하가 생기지 않을까요..?

서버의 사진/영상을 url로 클라이언트에 전달해주는데 static 폴더 설정이 있어야 클라이언트에서 볼 수 있지 않을까요??
