### PR TITLE
Feature/android/#42 story detail : 일정 스토리 권한 별 기능 동작, 일정 스토리 삭제

### DIFF
--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/model/EventStory.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/model/EventStory.kt
@@ -17,4 +17,4 @@ data class EventStory(
     val isVisible: Boolean,
     val memo: String?,
     val feeds: List<Feed>
-) : Serializable
+)

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/EventStoryApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/EventStoryApi.kt
@@ -3,6 +3,7 @@ package com.teameetmeet.meetmeet.data.network.api
 import com.teameetmeet.meetmeet.data.model.EventStory
 import com.teameetmeet.meetmeet.data.network.entity.SingleStringRequest
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -10,8 +11,11 @@ import retrofit2.http.Path
 interface EventStoryApi {
 
     @GET("/{id}/feeds")
-    fun getStory(@Path("id") id: String): EventStory
+    suspend fun getStory(@Path("id") id: String): EventStory
 
     @POST()
-    fun editNotification(@Body singleStringRequest: SingleStringRequest)
+    suspend fun editNotification(@Body singleStringRequest: SingleStringRequest)
+
+    @DELETE("event/{id}")
+    suspend fun deleteEventStory(@Path("id") id: Int)
 }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/FakeEventStoryApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/FakeEventStoryApi.kt
@@ -28,7 +28,7 @@ class FakeEventStoryApi : EventStoryApi {
 
             ),
             announcement = "다들 11시 반에 광명역에서 집합입니다~",
-            authority = "owner",
+            authority = "OWNER",
             repeatPolicyId = null,
             isJoin = true,
             isVisible = true,

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/FakeEventStoryApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/FakeEventStoryApi.kt
@@ -28,7 +28,7 @@ class FakeEventStoryApi : EventStoryApi {
 
             ),
             announcement = "다들 11시 반에 광명역에서 집합입니다~",
-            authority = "OWNER",
+            authority = "",
             repeatPolicyId = null,
             isJoin = true,
             isVisible = true,

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/FakeEventStoryApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/FakeEventStoryApi.kt
@@ -6,7 +6,7 @@ import com.teameetmeet.meetmeet.data.model.Feed
 import com.teameetmeet.meetmeet.data.network.entity.SingleStringRequest
 
 class FakeEventStoryApi : EventStoryApi {
-    override fun getStory(id: String): EventStory {
+    override suspend fun getStory(id: String): EventStory {
         return EventStory(
             id = 11,
             title = "밋밋 3차 오프라인 미팅",
@@ -28,7 +28,7 @@ class FakeEventStoryApi : EventStoryApi {
 
             ),
             announcement = "다들 11시 반에 광명역에서 집합입니다~",
-            authority = "",
+            authority = "OWNER",
             repeatPolicyId = null,
             isJoin = true,
             isVisible = true,
@@ -56,7 +56,11 @@ class FakeEventStoryApi : EventStoryApi {
         )
     }
 
-    override fun editNotification(singleStringRequest: SingleStringRequest) {
+    override suspend fun editNotification(singleStringRequest: SingleStringRequest) {
+
+    }
+
+    override suspend fun deleteEventStory(id: Int) {
 
     }
 }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/EventStoryRepository.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/EventStoryRepository.kt
@@ -31,6 +31,16 @@ class EventStoryRepository @Inject constructor(
         //TODO("이벤트 세부 정보 가져오고 로컬에 이벤트가 있으면 색과 알림 가져오기 아니면 DEFAULT 색 일정으로 파싱해서 내리기")
     }
 
+    fun deleteEventStory(id: Int) : Flow<Unit> {
+        return flowOf(true)
+            .map {
+                eventStoryApi.deleteEventStory(id)
+            }.catch {
+                throw it
+                //TODO(예외 처리 필요)
+            }
+    }
+
     fun editNotification(message: String) : Flow<Unit> {
         return flowOf(true)
             .map {

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/EventStoryBindingAdapter.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/EventStoryBindingAdapter.kt
@@ -1,21 +1,19 @@
 package com.teameetmeet.meetmeet.presentation.eventstory.eventstory
 
-import android.graphics.Rect
-import android.util.Log
-import android.view.View
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
-import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.appbar.MaterialToolbar
 import com.teameetmeet.meetmeet.R
-import com.teameetmeet.meetmeet.data.model.EventMember
 import com.teameetmeet.meetmeet.data.model.EventStory
-import com.teameetmeet.meetmeet.data.model.Feed
-import com.teameetmeet.meetmeet.presentation.eventstory.eventstory.adapter.EventFeedListAdapter
-import com.teameetmeet.meetmeet.presentation.eventstory.eventstory.adapter.EventMemberListAdapter
-import com.teameetmeet.meetmeet.util.convertDpToPx
+import com.teameetmeet.meetmeet.presentation.model.EventAuthority
 
 @BindingAdapter("event_story")
 fun TextView.bindTextViewDate(eventStory: EventStory?) {
     eventStory ?: return
     text = String.format(context.getString(R.string.event_story_event_date), eventStory.startDate, eventStory.endDate)
+}
+
+@BindingAdapter("menu_more_enable")
+fun MaterialToolbar.bindMenuEnable(eventAuthority: EventAuthority){
+    menu.findItem(R.id.menu_see_more_event_story).isVisible = eventAuthority != EventAuthority.GUEST
 }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/EventStoryFragment.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/EventStoryFragment.kt
@@ -14,8 +14,12 @@ import com.teameetmeet.meetmeet.databinding.FragmentEventStoryBinding
 import com.teameetmeet.meetmeet.presentation.base.BaseFragment
 import com.teameetmeet.meetmeet.presentation.eventstory.eventstory.adapter.EventFeedListAdapter
 import com.teameetmeet.meetmeet.presentation.eventstory.eventstory.adapter.EventMemberListAdapter
+import com.teameetmeet.meetmeet.presentation.model.EventAuthority
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -47,10 +51,14 @@ class EventStoryFragment : BaseFragment<FragmentEventStoryBinding>(R.layout.frag
                 showDialog(viewModel.getNoti())
             }
             eventStoryIbSeeMoreMember.setOnClickListener {
-                Log.d("test", "hi")
+                //TODO("더보기")
             }
             eventStoryCvInviteMember.setOnClickListener {
-                Log.d("test", "bye")
+                when(viewModel.eventStoryUiState.value.authority) {
+                    EventAuthority.GUEST -> {}//TODO("참여 신청")
+                    EventAuthority.OWNER -> {}//TODO("초대 페이지로 이동")
+                    else -> return@setOnClickListener
+                }
             }
         }
     }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/EventStoryUiState.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/EventStoryUiState.kt
@@ -1,11 +1,13 @@
 package com.teameetmeet.meetmeet.presentation.eventstory.eventstory
 
 import com.teameetmeet.meetmeet.data.model.EventStory
+import com.teameetmeet.meetmeet.presentation.model.EventAuthority
 
 data class EventStoryUiState(
     val eventStory: EventStory? = null,
     val isEventMemberUiExpanded: Boolean = false,
     val isLoading: Boolean = false,
+    val authority: EventAuthority = EventAuthority.GUEST,
     val maxMember: Int = SHRINK_MAX_MEMBER
 )
 

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/EventStoryUiState.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/EventStoryUiState.kt
@@ -8,7 +8,7 @@ data class EventStoryUiState(
     val isEventMemberUiExpanded: Boolean = false,
     val isLoading: Boolean = false,
     val authority: EventAuthority = EventAuthority.GUEST,
-    val maxMember: Int = SHRINK_MAX_MEMBER
+    val maxMember: Int = SHRINK_MAX_MEMBER,
 )
 
 const val EXPANDED_MAX_MEMBER = 5

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/EventStoryViewModel.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/EventStoryViewModel.kt
@@ -58,6 +58,7 @@ class EventStoryViewModel @Inject constructor(
         return eventStoryUiState.value.eventStory?.announcement.orEmpty()
     }
 
+
     override fun onItemClick(viewHolder: RecyclerView.ViewHolder) {
         when(viewHolder) {
             is EventFeedListAdapter.EventFeedViewHolder -> {

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/EventStoryViewModel.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/EventStoryViewModel.kt
@@ -7,6 +7,7 @@ import com.teameetmeet.meetmeet.R
 import com.teameetmeet.meetmeet.data.repository.EventStoryRepository
 import com.teameetmeet.meetmeet.presentation.eventstory.eventstory.adapter.EventFeedListAdapter
 import com.teameetmeet.meetmeet.presentation.eventstory.eventstory.adapter.EventMemberListAdapter
+import com.teameetmeet.meetmeet.presentation.model.EventAuthority
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.channels.BufferOverflow
@@ -41,7 +42,13 @@ class EventStoryViewModel @Inject constructor(
                 _event.emit(EventStoryEvent.ShowMessage(R.string.event_story_message_event_story_fail, it.message.orEmpty()))
             }.collect { eventStory ->
                 _eventStoryUiState.update {
-                    it.copy(eventStory = eventStory, isLoading = false)
+                    it.copy(eventStory = eventStory, isLoading = false, authority =
+                        when(eventStory.authority) {
+                            "OWNER" -> EventAuthority.OWNER
+                            "MEMBER" -> EventAuthority.PARTICIPANT
+                            else -> EventAuthority.GUEST
+                        }
+                    )
                 }
             }
         }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstorydetail/EventStoryDetailBindingAdapter.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstorydetail/EventStoryDetailBindingAdapter.kt
@@ -1,6 +1,5 @@
 package com.teameetmeet.meetmeet.presentation.eventstory.eventstorydetail
 
-import android.util.Log
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import com.google.android.material.appbar.MaterialToolbar
@@ -15,6 +14,5 @@ fun TextView.bindEventTime(eventTime: EventTime) {
 
 @BindingAdapter("menu_enable")
 fun MaterialToolbar.bindMenuEnable(eventAuthority: EventAuthority){
-    Log.d("test" , eventAuthority.toString())
     menu.findItem(R.id.menu_save).isVisible = eventAuthority != EventAuthority.GUEST
 }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstorydetail/EventStoryDetailEvent.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstorydetail/EventStoryDetailEvent.kt
@@ -2,4 +2,5 @@ package com.teameetmeet.meetmeet.presentation.eventstory.eventstorydetail
 
 sealed class EventStoryDetailEvent{
     data class ShowMessage(val messageId: Int, val extraMessage: String = "") : EventStoryDetailEvent()
+    data object FinishEventStoryActivity : EventStoryDetailEvent()
 }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstorydetail/EventStoryDetailFragment.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstorydetail/EventStoryDetailFragment.kt
@@ -30,12 +30,17 @@ class EventStoryDetailFragment : BaseFragment<FragmentEventStoryDetailBinding>(R
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setBinding()
-        viewModel.fetchStoryDetail(args.storyId)
+        fetchStoryDetail()
         setNotificationOptions()
         setRepeatOptions()
         setDateTimePicker()
         collectViewModelEvent()
         setTopAppBar()
+    }
+
+    private fun fetchStoryDetail() {
+        viewModel.fetchEventId(args.storyId)
+        viewModel.fetchStoryDetail()
     }
 
     private fun setTopAppBar() {
@@ -50,6 +55,7 @@ class EventStoryDetailFragment : BaseFragment<FragmentEventStoryDetailBinding>(R
                 viewModel.event.collect { event ->
                     when(event) {
                         is EventStoryDetailEvent.ShowMessage -> showMessage(event.messageId, event.extraMessage)
+                        is EventStoryDetailEvent.FinishEventStoryActivity -> requireActivity().finish()
                     }
                 }
             }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstorydetail/EventStoryDetailUiState.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstorydetail/EventStoryDetailUiState.kt
@@ -7,6 +7,7 @@ import com.teameetmeet.meetmeet.presentation.model.EventRepeatTerm
 import com.teameetmeet.meetmeet.presentation.model.EventTime
 
 data class EventStoryDetailUiState(
+    val eventId: Int = 0,
     val eventName: String ="",
     val startDate: String = "미정",
     val endDate: String = "미정",

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstorydetail/EventStoryDetailViewModel.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstorydetail/EventStoryDetailViewModel.kt
@@ -1,10 +1,13 @@
 package com.teameetmeet.meetmeet.presentation.eventstory.eventstorydetail
 
+import android.util.Log
+import android.widget.RadioGroup
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.teameetmeet.meetmeet.R
 import com.teameetmeet.meetmeet.data.repository.EventStoryRepository
 import com.teameetmeet.meetmeet.presentation.model.EventAuthority
+import com.teameetmeet.meetmeet.presentation.model.EventColor
 import com.teameetmeet.meetmeet.presentation.model.EventNotification
 import com.teameetmeet.meetmeet.presentation.model.EventRepeatTerm
 import com.teameetmeet.meetmeet.presentation.model.EventTime
@@ -27,7 +30,7 @@ class EventStoryDetailViewModel @Inject constructor(
     private val eventStoryRepository: EventStoryRepository
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow<EventStoryDetailUiState>(EventStoryDetailUiState())
+    private val _uiState = MutableStateFlow<EventStoryDetailUiState>(EventStoryDetailUiState(authority = EventAuthority.OWNER))
     val uiState: StateFlow<EventStoryDetailUiState> = _uiState
 
     private val _event = MutableSharedFlow<EventStoryDetailEvent>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
@@ -123,5 +126,13 @@ class EventStoryDetailViewModel @Inject constructor(
         _uiState.update {
             it.copy(endTime = EventTime(hour, min))
         }
+    }
+
+    fun setEventColor(radioGroup: RadioGroup, id: Int) {
+        val index = radioGroup.indexOfChild(radioGroup.findViewById(id))
+        _uiState.update {
+            it.copy(color = EventColor.values()[index])
+        }
+        Log.d("test", uiState.value.toString())
     }
 }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstorydetail/EventStoryDetailViewModel.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstorydetail/EventStoryDetailViewModel.kt
@@ -36,16 +36,30 @@ class EventStoryDetailViewModel @Inject constructor(
     private val _event = MutableSharedFlow<EventStoryDetailEvent>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
     val event : SharedFlow<EventStoryDetailEvent> = _event
 
+    fun fetchEventId(storyId: Int) {
+        _uiState.update {
+            it.copy(eventId = storyId)
+        }
+    }
 
-    fun fetchStoryDetail(storyId: Int) {
+    fun fetchStoryDetail() {
         viewModelScope.launch {
-            eventStoryRepository.getEventStoryDetail(storyId).catch {
+            eventStoryRepository.getEventStoryDetail(uiState.value.eventId).catch {
                 _event.tryEmit(EventStoryDetailEvent.ShowMessage(R.string.story_detail_message_story_detail_fetch_fail, it.message.orEmpty()))
             }.collect {
                 //TODO("event 세부 사항 정보 갱신")
             }
         }
+    }
 
+    fun deleteEvent() {
+        viewModelScope.launch {
+            eventStoryRepository.deleteEventStory(uiState.value.eventId).catch {
+                _event.tryEmit(EventStoryDetailEvent.ShowMessage(R.string.story_detail_message_event_story_delete_fail, it.message.orEmpty()))
+            }.collect {
+                _event.tryEmit(EventStoryDetailEvent.FinishEventStoryActivity)
+            }
+        }
     }
 
     fun setEventName(name: CharSequence) {

--- a/android/app/src/main/res/layout/fragment_event_story.xml
+++ b/android/app/src/main/res/layout/fragment_event_story.xml
@@ -52,6 +52,7 @@
                             android:background="@color/white"
                             android:minHeight="?attr/actionBarSize"
                             app:menu="@menu/menu_top_app_bar_event_story"
+                            app:menu_more_enable="@{vm.eventStoryUiState.authority}"
                             app:navigationIcon="@drawable/ic_nav_pre"
                             app:title="@{vm.eventStoryUiState.eventStory.title ?? @string/common_none}"
                             tools:title="밋밋 3차 오프라인 미팅" />

--- a/android/app/src/main/res/layout/fragment_event_story.xml
+++ b/android/app/src/main/res/layout/fragment_event_story.xml
@@ -9,203 +9,227 @@
             name="vm"
             type="com.teameetmeet.meetmeet.presentation.eventstory.eventstory.EventStoryViewModel" />
 
+        <import type="com.teameetmeet.meetmeet.presentation.model.EventAuthority"/>
+
         <import type="android.view.View" />
     </data>
 
-    <androidx.core.widget.NestedScrollView
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/layout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/white">
+            android:layout_height="match_parent"
+            >
 
-            <com.google.android.material.appbar.AppBarLayout
-                android:id="@+id/event_story_abl"
-                android:layout_width="0dp"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:fitsSystemWindows="true"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
+                android:background="@color/white">
 
-                <com.google.android.material.appbar.CollapsingToolbarLayout
-                    style="?attr/collapsingToolbarLayoutMediumStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="?attr/collapsingToolbarLayoutMediumSize"
-                    app:expandedTitleTextAppearance="@style/large.bold"
-                    app:maxLines="1">
+                <com.google.android.material.appbar.AppBarLayout
+                    android:id="@+id/event_story_abl"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:fitsSystemWindows="true"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent">
 
-                    <com.google.android.material.appbar.MaterialToolbar
-                        android:id="@+id/event_story_tbl"
+                    <com.google.android.material.appbar.CollapsingToolbarLayout
+                        style="?attr/collapsingToolbarLayoutMediumStyle"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:background="@color/white"
-                        android:minHeight="?attr/actionBarSize"
-                        app:menu="@menu/menu_top_app_bar_event_story"
-                        app:navigationIcon="@drawable/ic_nav_pre"
-                        app:title="@{vm.eventStoryUiState.eventStory.title ?? @string/common_none}"
-                        tools:title="밋밋 3차 오프라인 미팅" />
+                        android:layout_height="?attr/collapsingToolbarLayoutMediumSize"
+                        app:expandedTitleTextAppearance="@style/large.bold"
+                        app:maxLines="1">
 
-                </com.google.android.material.appbar.CollapsingToolbarLayout>
+                        <com.google.android.material.appbar.MaterialToolbar
+                            android:id="@+id/event_story_tbl"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:background="@color/white"
+                            android:minHeight="?attr/actionBarSize"
+                            app:menu="@menu/menu_top_app_bar_event_story"
+                            app:navigationIcon="@drawable/ic_nav_pre"
+                            app:title="@{vm.eventStoryUiState.eventStory.title ?? @string/common_none}"
+                            tools:title="밋밋 3차 오프라인 미팅" />
 
-            </com.google.android.material.appbar.AppBarLayout>
+                    </com.google.android.material.appbar.CollapsingToolbarLayout>
 
-            <TextView
-                android:id="@+id/event_story_tv_title_event_time"
-                style="@style/medium.bold"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_margin="16dp"
-                android:text="@string/event_story_title_event_time"
-                android:visibility="@{vm.eventStoryUiState.loading == true ? View.GONE : View.VISIBLE}"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/event_story_abl" />
+                </com.google.android.material.appbar.AppBarLayout>
 
-            <TextView
-                android:id="@+id/event_story_tv_value_event_time"
-                style="@style/small"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="12dp"
-                app:event_story="@{vm.eventStoryUiState.eventStory}"
-                app:layout_constraintStart_toStartOf="@id/event_story_tv_title_event_time"
-                app:layout_constraintTop_toBottomOf="@id/event_story_tv_title_event_time"
-                tools:text="2023.11.06 11:30 - 2023.11.06 21:30" />
-
-            <TextView
-                android:id="@+id/event_story_tv_title_event_members"
-                style="@style/medium.bold"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:text="@string/event_story_title_event_members"
-                android:visibility="@{vm.eventStoryUiState.loading == true ? View.GONE : View.VISIBLE}"
-                app:layout_constraintStart_toStartOf="@id/event_story_tv_title_event_time"
-                app:layout_constraintTop_toBottomOf="@id/event_story_tv_value_event_time" />
-
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/event_story_rv_value_event_members"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                app:is_expanded="@{vm.eventStoryUiState.eventMemberUiExpanded}"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                app:sub_list="@{vm.eventStoryUiState.eventStory.eventMembers}"
-                app:limit="@{vm.eventStoryUiState.maxMember}"
-                tools:itemCount="30"
-                app:layout_constraintStart_toStartOf="@id/event_story_tv_title_event_time"
-                app:layout_constraintTop_toBottomOf="@id/event_story_tv_title_event_members"
-                tools:listitem="@layout/item_event_member" />
-
-            <ImageButton
-                android:id="@+id/event_story_ib_see_more_member"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_marginStart="12dp"
-                android:layout_marginEnd="8dp"
-                android:background="@null"
-                android:foreground="?attr/selectableItemBackgroundBorderless"
-                android:src="@drawable/ic_more_hoz"
-                android:visibility="@{vm.eventStoryUiState.eventMemberUiExpanded == true ? View.VISIBLE : View.GONE}"
-                app:layout_constraintStart_toEndOf="@id/event_story_rv_value_event_members"
-                app:layout_constraintTop_toTopOf="@id/event_story_rv_value_event_members"
-                app:layout_constraintBottom_toBottomOf="@id/event_story_rv_value_event_members"
-                />
-
-            <androidx.cardview.widget.CardView
-                android:id="@+id/event_story_cv_invite_member"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:foreground="?attr/selectableItemBackgroundBorderless"
-                android:visibility="@{vm.eventStoryUiState.eventMemberUiExpanded == true ? View.VISIBLE : View.GONE}"
-                app:cardCornerRadius="100dp"
-                android:layout_marginStart="12dp"
-                app:layout_constraintStart_toEndOf="@id/event_story_ib_see_more_member"
-                app:layout_constraintTop_toTopOf="@id/event_story_rv_value_event_members"
-                app:layout_constraintBottom_toBottomOf="@id/event_story_rv_value_event_members"
-                app:contentPadding="6dp">
-
-                <ImageView
+                <TextView
+                    android:id="@+id/event_story_tv_title_event_time"
+                    style="@style/medium.bold"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:backgroundTint="@color/black"
-                    android:src="@drawable/ic_plus" />
+                    android:layout_margin="16dp"
+                    android:text="@string/event_story_title_event_time"
+                    android:visibility="@{vm.eventStoryUiState.loading == true ? View.GONE : View.VISIBLE}"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/event_story_abl" />
 
-            </androidx.cardview.widget.CardView>
+                <TextView
+                    android:id="@+id/event_story_tv_value_event_time"
+                    style="@style/small"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    app:event_story="@{vm.eventStoryUiState.eventStory}"
+                    app:layout_constraintStart_toStartOf="@id/event_story_tv_title_event_time"
+                    app:layout_constraintTop_toBottomOf="@id/event_story_tv_title_event_time"
+                    tools:text="2023.11.06 11:30 - 2023.11.06 21:30" />
 
-
-            <TextView
-                android:id="@+id/event_story_tv_title_event_notification"
-                style="@style/medium.bold"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:text="@string/event_story_title_event_notification"
-                android:visibility="@{vm.eventStoryUiState.loading == true ? View.GONE : View.VISIBLE}"
-                app:layout_constraintStart_toStartOf="@id/event_story_tv_title_event_time"
-                app:layout_constraintTop_toBottomOf="@id/event_story_rv_value_event_members" />
-
-            <ImageView
-                android:id="@+id/event_story_iv_change_notification"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:background="@null"
-                android:src="@drawable/ic_edit"
-                app:layout_constraintBottom_toBottomOf="@id/event_story_tv_title_event_notification"
-                app:layout_constraintStart_toEndOf="@id/event_story_tv_title_event_notification"
-                app:layout_constraintTop_toTopOf="@id/event_story_tv_title_event_notification" />
-
-            <TextView
-                android:id="@+id/event_story_tv_value_event_notification"
-                style="@style/small"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="12dp"
-                android:layout_marginEnd="16dp"
-                android:ellipsize="end"
-                android:foreground="?attr/selectableItemBackgroundBorderless"
-                android:maxLines="3"
-                android:text="@{vm.eventStoryUiState.eventStory.announcement ?? @string/common_none}"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="@id/event_story_tv_title_event_notification"
-                app:layout_constraintTop_toBottomOf="@id/event_story_tv_title_event_notification"
-                tools:text="다들 11시 반까지 광명역 앞으로 집합해주세요~" />
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/event_story_rv_event_feed"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
-                android:layout_marginEnd="16dp"
-                app:count_of_span="@{3}"
-                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="@id/event_story_tv_title_event_time"
-                app:layout_constraintTop_toBottomOf="@id/event_story_tv_value_event_notification"
-                app:spanCount="3"
-                app:sub_list="@{vm.eventStoryUiState.eventStory.feeds}" />
-
-            <ImageView
-                android:id="@+id/event_story_iv_loading"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:contentDescription="@string/event_story_description_loading_image"
-                android:src="@drawable/loading_animation"
-                android:visibility="@{vm.eventStoryUiState.loading == true ? View.VISIBLE : View.GONE}"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                <TextView
+                    android:id="@+id/event_story_tv_title_event_members"
+                    style="@style/medium.bold"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="@string/event_story_title_event_members"
+                    android:visibility="@{vm.eventStoryUiState.loading == true ? View.GONE : View.VISIBLE}"
+                    app:layout_constraintStart_toStartOf="@id/event_story_tv_title_event_time"
+                    app:layout_constraintTop_toBottomOf="@id/event_story_tv_value_event_time" />
 
 
-    </androidx.core.widget.NestedScrollView>
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/event_story_rv_value_event_members"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    app:is_expanded="@{vm.eventStoryUiState.eventMemberUiExpanded}"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                    app:sub_list="@{vm.eventStoryUiState.eventStory.eventMembers}"
+                    app:limit="@{vm.eventStoryUiState.maxMember}"
+                    tools:itemCount="30"
+                    app:layout_constraintStart_toStartOf="@id/event_story_tv_title_event_time"
+                    app:layout_constraintTop_toBottomOf="@id/event_story_tv_title_event_members"
+                    tools:listitem="@layout/item_event_member" />
+
+                <ImageButton
+                    android:id="@+id/event_story_ib_see_more_member"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginStart="12dp"
+                    android:layout_marginEnd="8dp"
+                    android:background="@null"
+                    android:foreground="?attr/selectableItemBackgroundBorderless"
+                    android:src="@drawable/ic_more_hoz"
+                    android:visibility="@{vm.eventStoryUiState.eventMemberUiExpanded == true ? View.VISIBLE : View.GONE}"
+                    app:layout_constraintStart_toEndOf="@id/event_story_rv_value_event_members"
+                    app:layout_constraintTop_toTopOf="@id/event_story_rv_value_event_members"
+                    app:layout_constraintBottom_toBottomOf="@id/event_story_rv_value_event_members"
+                    />
+
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/event_story_cv_invite_member"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:foreground="?attr/selectableItemBackgroundBorderless"
+                    android:visibility="@{(vm.eventStoryUiState.eventMemberUiExpanded == true &amp;&amp; vm.eventStoryUiState.authority != EventAuthority.PARTICIPANT) ? View.VISIBLE : View.GONE}"
+                    app:cardCornerRadius="100dp"
+                    android:layout_marginStart="12dp"
+                    app:layout_constraintStart_toEndOf="@id/event_story_ib_see_more_member"
+                    app:layout_constraintTop_toTopOf="@id/event_story_rv_value_event_members"
+                    app:layout_constraintBottom_toBottomOf="@id/event_story_rv_value_event_members"
+                    app:contentPadding="6dp">
+
+                    <ImageView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:backgroundTint="@color/black"
+                        android:src="@drawable/ic_plus" />
+
+                </androidx.cardview.widget.CardView>
+
+
+                <TextView
+                    android:id="@+id/event_story_tv_title_event_notification"
+                    style="@style/medium.bold"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="@string/event_story_title_event_notification"
+                    android:visibility="@{vm.eventStoryUiState.loading == true ? View.GONE : View.VISIBLE}"
+                    app:layout_constraintStart_toStartOf="@id/event_story_tv_title_event_time"
+                    app:layout_constraintTop_toBottomOf="@id/event_story_rv_value_event_members" />
+
+                <ImageView
+                    android:id="@+id/event_story_iv_change_notification"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:background="@null"
+                    android:src="@drawable/ic_edit"
+                    android:visibility="@{vm.eventStoryUiState.authority == EventAuthority.OWNER ? View.VISIBLE : View.GONE}"
+                    app:layout_constraintBottom_toBottomOf="@id/event_story_tv_title_event_notification"
+                    app:layout_constraintStart_toEndOf="@id/event_story_tv_title_event_notification"
+                    app:layout_constraintTop_toTopOf="@id/event_story_tv_title_event_notification" />
+
+                <TextView
+                    android:id="@+id/event_story_tv_value_event_notification"
+                    style="@style/small"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:layout_marginEnd="16dp"
+                    android:ellipsize="end"
+                    android:foreground="?attr/selectableItemBackgroundBorderless"
+                    android:maxLines="3"
+                    android:text="@{vm.eventStoryUiState.eventStory.announcement ?? @string/common_none}"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="@id/event_story_tv_title_event_notification"
+                    app:layout_constraintTop_toBottomOf="@id/event_story_tv_title_event_notification"
+                    tools:text="다들 11시 반까지 광명역 앞으로 집합해주세요~" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/event_story_rv_event_feed"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:layout_marginEnd="16dp"
+                    app:count_of_span="@{3}"
+                    app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="@id/event_story_tv_title_event_time"
+                    app:layout_constraintTop_toBottomOf="@id/event_story_tv_value_event_notification"
+                    app:spanCount="3"
+                    app:sub_list="@{vm.eventStoryUiState.eventStory.feeds}" />
+
+                <ImageView
+                    android:id="@+id/event_story_iv_loading"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:contentDescription="@string/event_story_description_loading_image"
+                    android:src="@drawable/loading_animation"
+                    android:visibility="@{vm.eventStoryUiState.loading == true ? View.VISIBLE : View.GONE}"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </androidx.core.widget.NestedScrollView>
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/event_story_fab_make_feed"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_margin="24dp"
+            android:src="@drawable/ic_plus"
+            android:visibility="@{vm.eventStoryUiState.authority == EventAuthority.GUEST ? View.GONE : View.VISIBLE}"
+            />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
 
 </layout>

--- a/android/app/src/main/res/layout/fragment_event_story_detail.xml
+++ b/android/app/src/main/res/layout/fragment_event_story_detail.xml
@@ -154,8 +154,8 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="24dp"
-                android:hint="@string/story_detail_event_alarm"
                 android:enabled="@{vm.uiState.authority == EventAuthority.GUEST ? false : true}"
+                android:hint="@string/story_detail_event_alarm"
                 app:layout_constraintEnd_toEndOf="@id/story_detail_guideline_right"
                 app:layout_constraintStart_toStartOf="@id/story_detail_guideline_left"
                 app:layout_constraintTop_toBottomOf="@id/story_detail_tv_value_end_time">
@@ -181,14 +181,82 @@
                 app:layout_constraintStart_toStartOf="@id/story_detail_guideline_left"
                 app:layout_constraintTop_toBottomOf="@id/story_detail_til_event_alarm" />
 
+            <RadioGroup
+                android:id="@+id/radio_group_event_color"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:checkedButton="@id/radio_red"
+                android:onCheckedChanged="@{(group, id) -> vm.setEventColor(group, id)}"
+                android:orientation="horizontal"
+                app:layout_constraintBottom_toBottomOf="@id/event_story_tv_event_color"
+                app:layout_constraintStart_toEndOf="@id/event_story_tv_event_color"
+                app:layout_constraintTop_toTopOf="@id/event_story_tv_event_color">
+
+                <RadioButton
+                    android:id="@+id/radio_red"
+                    android:layout_width="45dp"
+                    android:layout_height="45dp"
+                    android:layout_marginStart="9dp"
+                    android:background="@drawable/radio_button_event_color"
+                    android:backgroundTint="@color/event_color_red"
+                    android:backgroundTintMode="multiply"
+                    android:button="@android:color/transparent"
+                    android:enabled="@{vm.uiState.authority == EventAuthority.GUEST ? false : true}" />
+
+                <RadioButton
+                    android:id="@+id/radio_orange"
+                    android:layout_width="45dp"
+                    android:layout_height="45dp"
+                    android:layout_marginStart="9dp"
+                    android:background="@drawable/radio_button_event_color"
+                    android:backgroundTint="@color/event_color_orange"
+                    android:backgroundTintMode="multiply"
+                    android:button="@android:color/transparent"
+                    android:enabled="@{vm.uiState.authority == EventAuthority.GUEST ? false : true}" />
+
+                <RadioButton
+                    android:id="@+id/radio_green"
+                    android:layout_width="45dp"
+                    android:layout_height="45dp"
+                    android:layout_marginStart="9dp"
+                    android:background="@drawable/radio_button_event_color"
+                    android:backgroundTint="@color/event_color_green"
+                    android:backgroundTintMode="multiply"
+                    android:button="@android:color/transparent"
+                    android:enabled="@{vm.uiState.authority == EventAuthority.GUEST ? false : true}" />
+
+                <RadioButton
+                    android:id="@+id/radio_blue"
+                    android:layout_width="45dp"
+                    android:layout_height="45dp"
+                    android:layout_marginStart="9dp"
+                    android:background="@drawable/radio_button_event_color"
+                    android:backgroundTint="@color/event_color_blue"
+                    android:backgroundTintMode="multiply"
+                    android:button="@android:color/transparent"
+                    android:enabled="@{vm.uiState.authority == EventAuthority.GUEST ? false : true}" />
+
+                <RadioButton
+                    android:id="@+id/radio_purple"
+                    android:layout_width="45dp"
+                    android:layout_height="45dp"
+                    android:layout_marginStart="9dp"
+                    android:background="@drawable/radio_button_event_color"
+                    android:backgroundTint="@color/event_color_purple"
+                    android:backgroundTintMode="multiply"
+                    android:button="@android:color/transparent"
+                    android:enabled="@{vm.uiState.authority == EventAuthority.GUEST ? false : true}" />
+            </RadioGroup>
+
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/story_detail_til_event_repeat"
                 style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="24dp"
-                android:hint="@string/story_detail_event_repeat"
                 android:enabled="@{vm.uiState.authority == EventAuthority.GUEST ? false : true}"
+                android:hint="@string/story_detail_event_repeat"
                 app:layout_constraintEnd_toEndOf="@id/story_detail_guideline_right"
                 app:layout_constraintStart_toStartOf="@id/story_detail_guideline_left"
                 app:layout_constraintTop_toBottomOf="@id/event_story_tv_event_color">
@@ -272,8 +340,8 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="24dp"
                 android:backgroundTint="@color/event_color_warning"
-                android:text="@string/story_detail_remove_event"
                 android:enabled="@{vm.uiState.authority == EventAuthority.OWNER ? true : false}"
+                android:text="@string/story_detail_remove_event"
                 app:layout_constraintEnd_toEndOf="@id/story_detail_guideline_right"
                 app:layout_constraintStart_toStartOf="@id/story_detail_guideline_left"
                 app:layout_constraintTop_toBottomOf="@id/story_detail_tv_event_joinable" />

--- a/android/app/src/main/res/layout/fragment_event_story_detail.xml
+++ b/android/app/src/main/res/layout/fragment_event_story_detail.xml
@@ -340,8 +340,9 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="24dp"
                 android:backgroundTint="@color/event_color_warning"
-                android:enabled="@{vm.uiState.authority == EventAuthority.OWNER ? true : false}"
+                android:enabled="@{vm.uiState.authority == EventAuthority.GUEST ? false : true}"
                 android:text="@string/story_detail_remove_event"
+                android:onClick="@{() -> vm.deleteEvent()}"
                 app:layout_constraintEnd_toEndOf="@id/story_detail_guideline_right"
                 app:layout_constraintStart_toStartOf="@id/story_detail_guideline_left"
                 app:layout_constraintTop_toBottomOf="@id/story_detail_tv_event_joinable" />

--- a/android/app/src/main/res/layout/fragment_event_story_detail.xml
+++ b/android/app/src/main/res/layout/fragment_event_story_detail.xml
@@ -155,6 +155,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="24dp"
                 android:hint="@string/story_detail_event_alarm"
+                android:enabled="@{vm.uiState.authority == EventAuthority.GUEST ? false : true}"
                 app:layout_constraintEnd_toEndOf="@id/story_detail_guideline_right"
                 app:layout_constraintStart_toStartOf="@id/story_detail_guideline_left"
                 app:layout_constraintTop_toBottomOf="@id/story_detail_tv_value_end_time">
@@ -187,6 +188,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="24dp"
                 android:hint="@string/story_detail_event_repeat"
+                android:enabled="@{vm.uiState.authority == EventAuthority.GUEST ? false : true}"
                 app:layout_constraintEnd_toEndOf="@id/story_detail_guideline_right"
                 app:layout_constraintStart_toStartOf="@id/story_detail_guideline_left"
                 app:layout_constraintTop_toBottomOf="@id/event_story_tv_event_color">

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -123,5 +123,6 @@
     <string name="story_detail_message_time_pick_start_time_fail">시작 시간이 종료 시간 보다 뒤로 설정할 수 없습니다.</string>
     <string name="story_detail_message_time_pick_end_time_fail">종료 시간이 시작 시간 보다 앞으로 설정할 수 없습니다.</string>
     <string name="story_detail_message_story_detail_fetch_fail">일정 세부 정보를 가져올 수 없습니다.\n%s</string>
+    <string name="story_detail_message_event_story_delete_fail">일정 삭제에 실패했습니다.\n%s</string>
 
 </resources>


### PR DESCRIPTION
## 개요


- 이슈번호 : #42 #16
- 일정 스토리의 권한 마다 버튼이 보이는 여부 다르게 구현, 일정 스토리 삭제 양식 구현


## 설명


- 일정 스토리의 권한 마다 일정 초대, 피드 생성, 더보기, 공지 등록 버튼을 보이거나 보이지 않도록 구현
- 일정 스토리 삭제 요청 양식 구현
- 일정 색 받기 구현


## 구현사진

![event_detail](https://github.com/boostcampwm2023/and08-meetmeet/assets/59364681/6a507b4c-9126-42d5-ad06-60ceac3ccde5)
