### PR TITLE
Feature/backend/#29 create feed: 피드 생성 API 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { FollowModule } from './follow/follow.module';
 import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
 import { ContentModule } from './content/content.module';
+import { FeedModule } from './feed/feed.module';
 
 @Module({
   imports: [
@@ -46,6 +47,7 @@ import { ContentModule } from './content/content.module';
     UserModule,
     AuthModule,
     ContentModule,
+    FeedModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/content/content.service.ts
+++ b/backend/src/content/content.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { Content } from './entities/content.entity';
 
 @Injectable()
@@ -10,13 +10,29 @@ export class ContentService {
   ) {}
 
   async createContent(file: Express.Multer.File) {
-    const content = this.contentRepository.create({
+    const content = this.createEntity(file);
+
+    return await this.contentRepository.save(content);
+  }
+
+  async createContentBulk(files: Array<Express.Multer.File>) {
+    const contents = files.reduce((acc, file) => {
+      const content = this.createEntity(file);
+      return [...acc, content];
+    }, []);
+
+    const insertResult = await this.contentRepository.insert(contents);
+    const contentsId = insertResult.identifiers.map((value) => value.id);
+
+    return await this.contentRepository.find({ where: { id: In(contentsId) } });
+  }
+
+  private createEntity(file: Express.Multer.File) {
+    return this.contentRepository.create({
       mimeType: file.mimetype,
       path: file.filename,
       type: file.mimetype.split('/').at(0),
     });
-
-    return await this.contentRepository.save(content);
   }
 
   async updateContent(id: number, file: Express.Multer.File) {

--- a/backend/src/event-member/event-memer.service.ts
+++ b/backend/src/event-member/event-memer.service.ts
@@ -55,4 +55,15 @@ export class EventMemberService {
     console.log(eventMembers);
     await this.eventMemberRepository.save(eventMembers);
   }
+
+  async getAuthorityOfUserByEventId(eventId: number, userId: number) {
+    const result = await this.eventMemberRepository.findOne({
+      select: { authority: { displayName: true } },
+      relations: ['authority'],
+      where: { event: { id: eventId }, user: { id: userId } },
+      // where: { userId: userId, eventId: eventId },
+    });
+
+    return result?.authority?.displayName;
+  }
 }

--- a/backend/src/feed/dto/create-feed.dto.ts
+++ b/backend/src/feed/dto/create-feed.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class CreateFeedDto {
+  @ApiProperty({ name: 'eventId', example: 1 })
+  @Type(() => Number)
+  @IsNotEmpty()
+  @IsInt()
+  eventId: number;
+
+  @ApiProperty({ name: 'memo', example: 'memo', required: false })
+  @IsOptional()
+  @IsNotEmpty()
+  @IsString()
+  memo: string;
+
+  @ApiProperty({
+    name: 'contents',
+    type: 'array',
+    items: { type: 'string', format: 'binary' },
+    required: false,
+  })
+  @IsOptional()
+  contents: Array<Express.Multer.File>;
+}

--- a/backend/src/feed/entities/feed.entity.ts
+++ b/backend/src/feed/entities/feed.entity.ts
@@ -5,6 +5,9 @@ import { User } from 'src/user/entities/user.entity';
 
 @Entity()
 export class Feed extends commonEntity {
+  @Column()
+  eventId: number;
+
   @ManyToOne(() => User, { nullable: false })
   author: User;
 

--- a/backend/src/feed/entities/feedContent.entity.ts
+++ b/backend/src/feed/entities/feedContent.entity.ts
@@ -1,1 +1,18 @@
-export class FeedContent {}
+import { Content } from 'src/content/entities/content.entity';
+import { Entity, ManyToOne, PrimaryColumn } from 'typeorm';
+import { Feed } from './feed.entity';
+
+@Entity()
+export class FeedContent {
+  @PrimaryColumn()
+  feedId: number;
+
+  @PrimaryColumn()
+  contentId: number;
+
+  @ManyToOne(() => Feed, { nullable: false })
+  feed: Feed;
+
+  @ManyToOne(() => Content, { nullable: false })
+  content: Content;
+}

--- a/backend/src/feed/feed.controller.ts
+++ b/backend/src/feed/feed.controller.ts
@@ -1,0 +1,44 @@
+import {
+  Body,
+  Controller,
+  Post,
+  UploadedFiles,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FilesInterceptor } from '@nestjs/platform-express';
+import {
+  ApiBearerAuth,
+  ApiConsumes,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { GetUser } from 'src/auth/get-user.decorator';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { multerOptions } from 'src/common/config/multer.config';
+import { User } from 'src/user/entities/user.entity';
+import { CreateFeedDto } from './dto/create-feed.dto';
+import { FeedService } from './feed.service';
+
+@ApiTags('feed')
+@Controller('feed')
+export class FeedController {
+  constructor(private readonly feedService: FeedService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @UseInterceptors(FilesInterceptor('contents', 10, multerOptions))
+  @Post()
+  @ApiOperation({
+    summary: '피드 생성 API',
+    description: '일정 멤버만 피드를 생성할 수 있습니다.',
+  })
+  @ApiBearerAuth()
+  @ApiConsumes('multipart/form-data')
+  createFeed(
+    @GetUser() user: User,
+    @UploadedFiles() contents: Array<Express.Multer.File>,
+    @Body() createFeedDto: CreateFeedDto,
+  ) {
+    return this.feedService.createFeed(user, contents, createFeedDto);
+  }
+}

--- a/backend/src/feed/feed.module.ts
+++ b/backend/src/feed/feed.module.ts
@@ -1,4 +1,19 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ContentModule } from 'src/content/content.module';
+import { EventMemberModule } from 'src/event-member/event-member.module';
+import { Feed } from './entities/feed.entity';
+import { FeedContent } from './entities/feedContent.entity';
+import { FeedController } from './feed.controller';
+import { FeedService } from './feed.service';
 
-@Module({})
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Feed, FeedContent]),
+    ContentModule,
+    EventMemberModule,
+  ],
+  controllers: [FeedController],
+  providers: [FeedService],
+})
 export class FeedModule {}

--- a/backend/src/feed/feed.service.ts
+++ b/backend/src/feed/feed.service.ts
@@ -1,0 +1,49 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ContentService } from 'src/content/content.service';
+import { EventMemberService } from 'src/event-member/event-memer.service';
+import { User } from 'src/user/entities/user.entity';
+import { Repository } from 'typeorm';
+import { CreateFeedDto } from './dto/create-feed.dto';
+import { Feed } from './entities/feed.entity';
+import { FeedContent } from './entities/feedContent.entity';
+
+@Injectable()
+export class FeedService {
+  constructor(
+    @InjectRepository(Feed) private feedRepository: Repository<Feed>,
+    @InjectRepository(FeedContent)
+    private feedContentRepository: Repository<FeedContent>,
+    private readonly contentService: ContentService,
+    private readonly eventMemberSercive: EventMemberService,
+  ) {}
+
+  async createFeed(
+    user: User,
+    files: Array<Express.Multer.File>,
+    createFeedDto: CreateFeedDto,
+  ) {
+    if (!files && !createFeedDto.memo) {
+      throw new BadRequestException('사진/영상/글을 작성해주세요.');
+    }
+
+    const authority = await this.eventMemberSercive.getAuthorityOfUserByEventId(
+      createFeedDto.eventId,
+      user.id,
+    );
+
+    if (!authority) {
+      throw new BadRequestException('일정 멤버만 피드를 추가할 수 있습니다.');
+    }
+
+    const feed = this.feedRepository.create({ ...createFeedDto, author: user });
+    const contents = await this.contentService.createContentBulk(files);
+    await this.feedRepository.save(feed);
+
+    const feedContents = contents.reduce((acc, content) => {
+      return [...acc, this.feedContentRepository.create({ feed, content })];
+    }, []);
+
+    await this.feedContentRepository.insert(feedContents);
+  }
+}


### PR DESCRIPTION
## 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

Issue: #29 
일정 멤버는 피드를 작성할 수 있다.

## 설명

<!-- 

- 현재 Pr 설명 

-->

요청을 보낸 사용자가 피드를 작성하고자 하는 일정의 멤버인지 확인한 후 일정 멤버라면 피드를 생성합니다.
피드에는 사진, 영상, 글이 들어갈 수 있으며 사진, 영상, 글 모두 null이 될 수는 없습니다.

## 고민거리 

<!-- (Optional) 의견 받고싶은 부분 있으면 적어두기

### Q. ui 이벤트 처리를 어디서 해야할 지 모르겠어요...

-->

`repository.save()` 안에 배열로 넣어줘도 `insert` -> `select`를 배열 길이만큼 반복한다.
-> `insert()`로 수정

swagger에서 memo가 비어있다면 request body에 포함시키지 않고 싶었는데 그러려면 memo에 빈 값을 넣고 `Send empty value`를 체크 해제해야 한다..

아직 파일 개수 10개 제한만 있고 전체 파일 크기에 대한 제한은 없습니다! (추후 구현 예정)

