### PR TITLE
fix: refresh 에러 해결

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,11 +1,10 @@
 import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiBearerAuth, ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { User } from 'src/user/entities/user.entity';
 import { AuthService } from './auth.service';
 import { AuthUserDto } from './dto/auth-user.dto';
 import { GetUser } from './get-user.decorator';
-import { JwtAuthGuard } from './jwt-auth.guard';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -51,9 +50,7 @@ export class AuthController {
     return this.authService.login(user);
   }
 
-  @UseGuards(JwtAuthGuard)
   @Post('refresh')
-  @ApiBearerAuth()
   @ApiOperation({
     summary: 'access token 갱신 API',
   })
@@ -68,11 +65,8 @@ export class AuthController {
       },
     },
   })
-  async refresh(
-    @GetUser() user: User,
-    @Body('refreshToken') refreshToken: string,
-  ) {
-    return this.authService.refresh(user, refreshToken);
+  async refresh(@Body('refreshToken') refreshToken: string) {
+    return this.authService.refresh(refreshToken);
   }
 
   @Get('check/token')

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -67,13 +67,15 @@ export class AuthService {
     };
   }
 
-  async refresh(user: User, refreshToken: string) {
+  async refresh(refreshToken: string) {
     const payload = this.jwtService.verify(refreshToken, {
       secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
     });
 
     // TODO: refresh token db 검증
-    if (user.id !== payload.id) {
+    const user = await this.userService.findUserByEmail(payload.email);
+
+    if (!user) {
       throw new UnauthorizedException('Invalid User');
     }
 
@@ -91,7 +93,7 @@ export class AuthService {
 
   async generateRefreshToken(user: User): Promise<string> {
     return await this.jwtService.signAsync(
-      { id: user.id },
+      { id: user.id, email: user.email },
       {
         secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
         expiresIn: this.configService.get<string>(

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -4,7 +4,6 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 import { User } from 'src/user/entities/user.entity';
 import { UserService } from 'src/user/user.service';
-import { TokenExpiredError } from '@nestjs/jwt';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -13,21 +12,18 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     private configService: ConfigService,
   ) {
     super({
-      ignoreExpiration: true,
+      // todo : ignoreExpiration true로 바꿀지 고민
+      ignoreExpiration: false,
       secretOrKey: configService.get('JWT_SECRET_KEY'),
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
     });
   }
 
-  async validate(payload: unknown): Promise<User> {
-    const { email, exp } = payload as any;
+  async validate(payload: { email: string }): Promise<User> {
+    const { email } = payload;
 
     if (!email) {
       throw new UnauthorizedException();
-    }
-
-    if (exp < new Date().getTime() / 1000) {
-      throw new TokenExpiredError('토큰이 만료되었습니다.', exp);
     }
 
     const user: User | null = await this.userService.findUserByEmail(email);


### PR DESCRIPTION
## 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

issue: #126 


## 설명

<!-- 

- 현재 Pr 설명 

-->

access token이 만료되면 refresh에서 에러가 발생하는 현상을 다시 수정했습니다..!
refresh 시 access token으로부터 얻은 user와 refresh user id 비교 -> refresh token만으로 user 확인
추후 refresh token을 저장해두는 것이 좋을 것 같습니다!