### PR TITLE
Feature/android/#43 kakao login server request : 로그인, 유저 관련 서버 연결

### DIFF
--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/ExceptionHandler.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/ExceptionHandler.kt
@@ -3,3 +3,4 @@ package com.teameetmeet.meetmeet.data
 
 class NoDataException : Exception() //데이터 요청 시 반환되는 데이터가 null일 경우
 class FirstSignIn(val accessToken: String, val responseToken: String) : Exception() // 최초 로그인 일 경우
+class ExpiredTokenException(): Exception()

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/model/UserProfile.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/model/UserProfile.kt
@@ -1,10 +1,14 @@
 package com.teameetmeet.meetmeet.data.model
 
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class UserProfile(
+    @Json(name = "profileUrl")
     val profileImage: String? = null,
+    @Json(name = "nickname")
     val nickname: String,
+    @Json(name = "email")
     val email: String
 )

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/EventStoryApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/EventStoryApi.kt
@@ -1,7 +1,7 @@
 package com.teameetmeet.meetmeet.data.network.api
 
 import com.teameetmeet.meetmeet.data.model.EventStory
-import com.teameetmeet.meetmeet.data.network.entity.SingleStringRequest
+import com.teameetmeet.meetmeet.data.network.entity.KakaoLoginRequest
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -14,7 +14,7 @@ interface EventStoryApi {
     suspend fun getStory(@Path("id") id: String): EventStory
 
     @POST()
-    suspend fun editNotification(@Body singleStringRequest: SingleStringRequest)
+    suspend fun editNotification(@Body singleStringRequest: KakaoLoginRequest)
 
     @DELETE("event/{id}")
     suspend fun deleteEventStory(@Path("id") id: Int)

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/FakeEventStoryApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/FakeEventStoryApi.kt
@@ -3,7 +3,7 @@ package com.teameetmeet.meetmeet.data.network.api
 import com.teameetmeet.meetmeet.data.model.EventMember
 import com.teameetmeet.meetmeet.data.model.EventStory
 import com.teameetmeet.meetmeet.data.model.Feed
-import com.teameetmeet.meetmeet.data.network.entity.SingleStringRequest
+import com.teameetmeet.meetmeet.data.network.entity.KakaoLoginRequest
 
 class FakeEventStoryApi : EventStoryApi {
     override suspend fun getStory(id: String): EventStory {
@@ -56,7 +56,7 @@ class FakeEventStoryApi : EventStoryApi {
         )
     }
 
-    override suspend fun editNotification(singleStringRequest: SingleStringRequest) {
+    override suspend fun editNotification(singleStringRequest: KakaoLoginRequest) {
 
     }
 

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/FakeLoginApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/FakeLoginApi.kt
@@ -5,13 +5,13 @@ import com.teameetmeet.meetmeet.data.FirstSignIn
 import com.teameetmeet.meetmeet.data.network.entity.AutoLoginRequest
 import com.teameetmeet.meetmeet.data.network.entity.AvailableResponse
 import com.teameetmeet.meetmeet.data.network.entity.EmailDuplicationCheckRequest
-import com.teameetmeet.meetmeet.data.network.entity.SingleStringRequest
+import com.teameetmeet.meetmeet.data.network.entity.KakaoLoginRequest
 import com.teameetmeet.meetmeet.data.network.entity.LoginResponse
 import com.teameetmeet.meetmeet.data.network.entity.SelfSignRequest
 import kotlin.random.Random
 
 class FakeLoginApi : LoginApi {
-    override fun loginKakao(singleStringRequest: SingleStringRequest): LoginResponse {
+    override suspend fun loginKakao(singleStringRequest: KakaoLoginRequest): LoginResponse {
         val case = Random.nextInt()
         Log.d("test", case.toString())
         if (case % 2 == 0) {

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/FakeLoginApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/FakeLoginApi.kt
@@ -2,7 +2,7 @@ package com.teameetmeet.meetmeet.data.network.api
 
 import android.util.Log
 import com.teameetmeet.meetmeet.data.FirstSignIn
-import com.teameetmeet.meetmeet.data.network.entity.AutoLoginRequest
+import com.teameetmeet.meetmeet.data.network.entity.AccessTokenResult
 import com.teameetmeet.meetmeet.data.network.entity.AvailableResponse
 import com.teameetmeet.meetmeet.data.network.entity.EmailDuplicationCheckRequest
 import com.teameetmeet.meetmeet.data.network.entity.KakaoLoginRequest
@@ -24,8 +24,8 @@ class FakeLoginApi : LoginApi {
         return LoginResponse("accessToken", "refreshToken")
     }
 
-    override fun autoLoginApp(autoLoginRequest: AutoLoginRequest): LoginResponse {
-        return LoginResponse("accessToken", "refreshToken")
+    override suspend fun autoLoginApp(accessToken: String): AccessTokenResult {
+        return AccessTokenResult(isVerified = true)
     }
 
     override fun checkEmailDuplication(emailDuplicationCheckRequest: EmailDuplicationCheckRequest): AvailableResponse {

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/FakeUserApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/FakeUserApi.kt
@@ -6,7 +6,7 @@ import com.teameetmeet.meetmeet.data.network.entity.NickNameDuplicationCheckRequ
 import kotlin.random.Random
 
 class FakeUserApi : UserApi {
-    override fun getUserProfile(accessToken: String): UserProfile {
+    override suspend fun getUserProfile(accessToken: String): UserProfile {
         return UserProfile(
             "https://i.ibb.co/024nfzT/rabbit.jpg",
             "코딩 천재 김근범",

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/LoginApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/LoginApi.kt
@@ -3,7 +3,7 @@ package com.teameetmeet.meetmeet.data.network.api
 import com.teameetmeet.meetmeet.data.network.entity.AutoLoginRequest
 import com.teameetmeet.meetmeet.data.network.entity.AvailableResponse
 import com.teameetmeet.meetmeet.data.network.entity.EmailDuplicationCheckRequest
-import com.teameetmeet.meetmeet.data.network.entity.SingleStringRequest
+import com.teameetmeet.meetmeet.data.network.entity.KakaoLoginRequest
 import com.teameetmeet.meetmeet.data.network.entity.LoginResponse
 import com.teameetmeet.meetmeet.data.network.entity.SelfSignRequest
 import retrofit2.http.Body
@@ -11,8 +11,8 @@ import retrofit2.http.POST
 
 interface LoginApi {
 
-    @POST("/auth/kakao/login")
-    fun loginKakao(@Body singleStringRequest: SingleStringRequest): LoginResponse
+    @POST("/auth/kakao")
+    suspend fun loginKakao(@Body kakaoLoginRequest: KakaoLoginRequest): LoginResponse
 
     @POST("/auth/login")
     fun loginSelf(@Body selfSignRequest: SelfSignRequest): LoginResponse

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/LoginApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/LoginApi.kt
@@ -1,24 +1,26 @@
 package com.teameetmeet.meetmeet.data.network.api
 
-import com.teameetmeet.meetmeet.data.network.entity.AutoLoginRequest
+import com.teameetmeet.meetmeet.data.network.entity.AccessTokenResult
 import com.teameetmeet.meetmeet.data.network.entity.AvailableResponse
 import com.teameetmeet.meetmeet.data.network.entity.EmailDuplicationCheckRequest
 import com.teameetmeet.meetmeet.data.network.entity.KakaoLoginRequest
 import com.teameetmeet.meetmeet.data.network.entity.LoginResponse
 import com.teameetmeet.meetmeet.data.network.entity.SelfSignRequest
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Query
 
 interface LoginApi {
 
-    @POST("/auth/kakao")
+    @POST("auth/kakao")
     suspend fun loginKakao(@Body kakaoLoginRequest: KakaoLoginRequest): LoginResponse
 
     @POST("/auth/login")
     fun loginSelf(@Body selfSignRequest: SelfSignRequest): LoginResponse
 
-    @POST()
-    fun autoLoginApp(@Body autoLoginRequest: AutoLoginRequest): LoginResponse
+    @GET("auth/check/token")
+    suspend fun autoLoginApp(@Query("token") accessToken: String): AccessTokenResult
 
     @POST()
     fun checkEmailDuplication(@Body emailDuplicationCheckRequest: EmailDuplicationCheckRequest): AvailableResponse

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/UserApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/UserApi.kt
@@ -5,12 +5,13 @@ import com.teameetmeet.meetmeet.data.network.entity.AvailableResponse
 import com.teameetmeet.meetmeet.data.network.entity.NickNameDuplicationCheckRequest
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface UserApi {
 
-    @GET
-    fun getUserProfile(accessToken: String): UserProfile
+    @GET("user/info")
+    suspend fun getUserProfile(@Header("Authorization") accessToken: String): UserProfile
 
     @POST()
     fun checkNickNameDuplication(@Body nickNameDuplicationCheckRequest: NickNameDuplicationCheckRequest): AvailableResponse

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/di/NetworkModule.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/di/NetworkModule.kt
@@ -1,10 +1,11 @@
 package com.teameetmeet.meetmeet.data.network.di
 
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.teameetmeet.meetmeet.data.network.api.CalendarApi
 import com.teameetmeet.meetmeet.data.network.api.EventStoryApi
 import com.teameetmeet.meetmeet.data.network.api.FakeCalendarApi
 import com.teameetmeet.meetmeet.data.network.api.FakeEventStoryApi
-import com.teameetmeet.meetmeet.data.network.api.FakeLoginApi
 import com.teameetmeet.meetmeet.data.network.api.FakeUserApi
 import com.teameetmeet.meetmeet.data.network.api.LoginApi
 import com.teameetmeet.meetmeet.data.network.api.UserApi
@@ -20,13 +21,24 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 class NetworkModule {
+
+    @Singleton
+    @Provides
+    fun provideMoshi(): Moshi {
+        return Moshi.Builder()
+            .addLast(KotlinJsonAdapterFactory())
+            .build()
+    }
+
     @Singleton
     @Provides
     @Named("serverRetrofit")
-    fun providesServerRetrofit(): Retrofit {
+    fun providesServerRetrofit(
+        moshi: Moshi
+    ): Retrofit {
         return Retrofit.Builder()
             .baseUrl("http://meetmeet.chani.pro/")
-            .addConverterFactory(MoshiConverterFactory.create())
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
             .build()
     }
 
@@ -36,7 +48,7 @@ class NetworkModule {
 
     @Singleton
     @Provides
-    fun provideLoginApi(): LoginApi = FakeLoginApi()
+    fun provideLoginApi(@Named("serverRetrofit")retrofit: Retrofit): LoginApi = retrofit.create(LoginApi::class.java)
 
     @Singleton
     @Provides

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/di/NetworkModule.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/di/NetworkModule.kt
@@ -15,6 +15,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.create
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -52,7 +53,7 @@ class NetworkModule {
 
     @Singleton
     @Provides
-    fun provideUserApi(): UserApi = FakeUserApi()
+    fun provideUserApi(@Named("serverRetrofit") retrofit: Retrofit): UserApi = retrofit.create(UserApi::class.java)
 
     @Singleton
     @Provides

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/entity/AccessTokenResult.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/entity/AccessTokenResult.kt
@@ -1,0 +1,10 @@
+package com.teameetmeet.meetmeet.data.network.entity
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class AccessTokenResult(
+    @Json(name = "isVerified")
+    val isVerified: Boolean
+)

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/entity/AutoLoginRequest.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/entity/AutoLoginRequest.kt
@@ -1,5 +1,0 @@
-package com.teameetmeet.meetmeet.data.network.entity
-
-data class AutoLoginRequest(
-    val accessToken: String
-)

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/entity/KakaoLoginRequest.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/entity/KakaoLoginRequest.kt
@@ -1,8 +1,10 @@
 package com.teameetmeet.meetmeet.data.network.entity
 
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-class SingleStringRequest (
-    val stringValue: String
+class KakaoLoginRequest (
+    @Json(name = "kakaoId")
+    val kakaoId: String
 )

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/EventStoryRepository.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/EventStoryRepository.kt
@@ -3,8 +3,7 @@ package com.teameetmeet.meetmeet.data.repository
 import com.teameetmeet.meetmeet.data.local.database.dao.EventDao
 import com.teameetmeet.meetmeet.data.model.EventStory
 import com.teameetmeet.meetmeet.data.network.api.EventStoryApi
-import com.teameetmeet.meetmeet.data.network.entity.SingleStringRequest
-import kotlinx.coroutines.delay
+import com.teameetmeet.meetmeet.data.network.entity.KakaoLoginRequest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOf
@@ -44,7 +43,7 @@ class EventStoryRepository @Inject constructor(
     fun editNotification(message: String) : Flow<Unit> {
         return flowOf(true)
             .map {
-                eventStoryApi.editNotification(SingleStringRequest(message))
+                eventStoryApi.editNotification(KakaoLoginRequest(message))
             }.catch {
                 throw it
             }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/LoginRepository.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/LoginRepository.kt
@@ -1,10 +1,10 @@
 package com.teameetmeet.meetmeet.data.repository
 
 import android.util.Log
+import com.teameetmeet.meetmeet.data.ExpiredTokenException
 import com.teameetmeet.meetmeet.data.FirstSignIn
 import com.teameetmeet.meetmeet.data.local.datastore.DataStoreHelper
 import com.teameetmeet.meetmeet.data.network.api.LoginApi
-import com.teameetmeet.meetmeet.data.network.entity.AutoLoginRequest
 import com.teameetmeet.meetmeet.data.network.entity.EmailDuplicationCheckRequest
 import com.teameetmeet.meetmeet.data.network.entity.KakaoLoginRequest
 import com.teameetmeet.meetmeet.data.network.entity.SelfSignRequest
@@ -52,8 +52,11 @@ class LoginRepository @Inject constructor(
     fun autoLoginApp(token: String): Flow<Unit> {
         return flowOf(true)
             .map {
-                val response = loginApi.autoLoginApp(AutoLoginRequest(token))
-                storeAppToken(response.accessToken, response.refreshToken)
+                val response = loginApi.autoLoginApp(accessToken = token)
+                Log.d("test", response.toString())
+                if(response.isVerified.not()) {
+                    throw ExpiredTokenException()
+                }
             }.catch {
                 throw it
                 //TODO("추가 예외처리 필요")

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/LoginRepository.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/LoginRepository.kt
@@ -1,11 +1,12 @@
 package com.teameetmeet.meetmeet.data.repository
 
+import android.util.Log
 import com.teameetmeet.meetmeet.data.FirstSignIn
 import com.teameetmeet.meetmeet.data.local.datastore.DataStoreHelper
 import com.teameetmeet.meetmeet.data.network.api.LoginApi
 import com.teameetmeet.meetmeet.data.network.entity.AutoLoginRequest
 import com.teameetmeet.meetmeet.data.network.entity.EmailDuplicationCheckRequest
-import com.teameetmeet.meetmeet.data.network.entity.SingleStringRequest
+import com.teameetmeet.meetmeet.data.network.entity.KakaoLoginRequest
 import com.teameetmeet.meetmeet.data.network.entity.SelfSignRequest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -21,9 +22,10 @@ class LoginRepository @Inject constructor(
         return flowOf(true)
             .map {
                 val response =
-                    loginApi.loginKakao(singleStringRequest = SingleStringRequest(id.toString()))
+                    loginApi.loginKakao(kakaoLoginRequest = KakaoLoginRequest(id.toString()))
                 storeAppToken(response.accessToken, response.refreshToken)
             }.catch {
+                Log.d("test", "$it")
                 when (it) {
                     is FirstSignIn -> {
                         storeAppToken(it.accessToken, it.responseToken)

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/UserRepository.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/UserRepository.kt
@@ -1,5 +1,6 @@
 package com.teameetmeet.meetmeet.data.repository
 
+import android.util.Log
 import com.teameetmeet.meetmeet.data.NoDataException
 import com.teameetmeet.meetmeet.data.local.datastore.DataStoreHelper
 import com.teameetmeet.meetmeet.data.network.api.UserApi
@@ -23,7 +24,8 @@ class UserRepository @Inject constructor(
         return flowOf(true)
             .map {
                 val token = dataStore.getAppToken().first() ?: throw NoDataException()
-                userApi.getUserProfile(token)
+                val result = userApi.getUserProfile("Bearer $token")
+                result
             }.onEach {
                 fetchUserProfile(it)
             }.catch {

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/UserRepository.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/UserRepository.kt
@@ -1,13 +1,10 @@
 package com.teameetmeet.meetmeet.data.repository
 
-import android.util.Log
 import com.teameetmeet.meetmeet.data.NoDataException
 import com.teameetmeet.meetmeet.data.local.datastore.DataStoreHelper
-import com.teameetmeet.meetmeet.data.network.api.UserApi
 import com.teameetmeet.meetmeet.data.model.UserProfile
-import com.teameetmeet.meetmeet.data.network.entity.EmailDuplicationCheckRequest
+import com.teameetmeet.meetmeet.data.network.api.UserApi
 import com.teameetmeet.meetmeet.data.network.entity.NickNameDuplicationCheckRequest
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/bindingadapter/ImageBindingAdapter.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/bindingadapter/ImageBindingAdapter.kt
@@ -10,6 +10,6 @@ fun ImageView.bindUserProfileImage(
     profileImage: String?
 ) {
     Glide.with(context).load(profileImage)
-        .centerCrop().fallback(R.drawable.ic_plus).error(R.drawable.ic_follow)
+        .centerCrop()
         .placeholder(R.drawable.ic_person).into(this)
 }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/calendar/CalendarViewModel.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/calendar/CalendarViewModel.kt
@@ -63,7 +63,7 @@ class CalendarViewModel @Inject constructor(
     private fun fetchUserProfile() {
         viewModelScope.launch {
             userRepository.getUserProfile().catch {
-                //TODO("유저 프로필을 못 불러올 때 어떻게 해야할 지 생각")
+                updateUserProfile(UserProfile(null, "", ""))
             }.collect { userProfile ->
                 updateUserProfile(userProfile)
             }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/splash/SplashViewModel.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/splash/SplashViewModel.kt
@@ -57,7 +57,6 @@ class SplashViewModel @Inject constructor(
             if (token.isNullOrEmpty()) {
                 _event.tryEmit(SplashEvent.NavigateToLoginActivity)
             } else {
-                Log.d("test", "$token")
                 autoLoginApp(token)
             }
         }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/splash/SplashViewModel.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/splash/SplashViewModel.kt
@@ -57,6 +57,7 @@ class SplashViewModel @Inject constructor(
             if (token.isNullOrEmpty()) {
                 _event.tryEmit(SplashEvent.NavigateToLoginActivity)
             } else {
+                Log.d("test", "$token")
                 autoLoginApp(token)
             }
         }


### PR DESCRIPTION
## 개요


- 이슈번호 : #45 #77 #43
- 카카오 로그인, accessToken 만료 검사, 유저 정보 가져오기 서버 연결


## 설명

- 카카오 로그인, accessToken 만료 검사, 유저 정보 가져오기 서버 연결
- 카카오 로그인은 추후에 최초 로그인 여부가 날아오면 수정 필요
- 스플래시 화면은 refresh token으로 accessToken이 갱신되는 것이 구현 되면 추가 필요


