### PR TITLE
feat: 서버 요청 시 Authorization header에 access token 자동으로 넣어지도록 설정

### DIFF
--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/ExceptionHandler.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/ExceptionHandler.kt
@@ -4,3 +4,4 @@ package com.teameetmeet.meetmeet.data
 class NoDataException : Exception() //데이터 요청 시 반환되는 데이터가 null일 경우
 class FirstSignIn(val accessToken: String, val responseToken: String) : Exception() // 최초 로그인 일 경우
 class ExpiredTokenException(): Exception()
+class ExpiredRefreshTokenException(): Exception() // refreshToken 만료인 경우

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/local/datastore/DataStoreHelper.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/local/datastore/DataStoreHelper.kt
@@ -25,6 +25,8 @@ class DataStoreHelper @Inject constructor(
 
     fun getAppToken(): Flow<String?> = dataStore.data.map { it[ACCESS_TOKEN] }
 
+    fun getRefreshToken(): Flow<String?> = dataStore.data.map {it[REFRESH_TOKEN]}
+
     suspend fun fetchUserProfile(userProfile: UserProfile) {
         dataStore.edit {
             it[USER_PROFILE_IMAGE] = userProfile.profileImage.orEmpty()

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/AuthApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/AuthApi.kt
@@ -1,0 +1,12 @@
+package com.teameetmeet.meetmeet.data.network.api
+
+import com.teameetmeet.meetmeet.data.network.entity.LoginResponse
+import com.teameetmeet.meetmeet.data.network.entity.RefreshAccessTokenRequest
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AuthApi {
+
+    @POST("auth/refresh")
+    fun refreshAccessToken(@Body refreshAccessTokenRequest: RefreshAccessTokenRequest): LoginResponse
+}

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/FakeUserApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/FakeUserApi.kt
@@ -6,7 +6,7 @@ import com.teameetmeet.meetmeet.data.network.entity.NickNameDuplicationCheckRequ
 import kotlin.random.Random
 
 class FakeUserApi : UserApi {
-    override suspend fun getUserProfile(accessToken: String): UserProfile {
+    override suspend fun getUserProfile(): UserProfile {
         return UserProfile(
             "https://i.ibb.co/024nfzT/rabbit.jpg",
             "코딩 천재 김근범",

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/UserApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/UserApi.kt
@@ -5,13 +5,12 @@ import com.teameetmeet.meetmeet.data.network.entity.AvailableResponse
 import com.teameetmeet.meetmeet.data.network.entity.NickNameDuplicationCheckRequest
 import retrofit2.http.Body
 import retrofit2.http.GET
-import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface UserApi {
 
     @GET("user/info")
-    suspend fun getUserProfile(@Header("Authorization") accessToken: String): UserProfile
+    suspend fun getUserProfile(): UserProfile
 
     @POST()
     fun checkNickNameDuplication(@Body nickNameDuplicationCheckRequest: NickNameDuplicationCheckRequest): AvailableResponse

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/entity/RefreshAccessTokenRequest.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/entity/RefreshAccessTokenRequest.kt
@@ -4,9 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-data class LoginResponse(
-    @Json(name = "accessToken")
-    val accessToken: String,
+data class RefreshAccessTokenRequest(
     @Json(name = "refreshToken")
     val refreshToken: String
 )

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/TokenRepository.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/TokenRepository.kt
@@ -1,0 +1,30 @@
+package com.teameetmeet.meetmeet.data.repository
+
+import com.teameetmeet.meetmeet.data.ExpiredRefreshTokenException
+import com.teameetmeet.meetmeet.data.NoDataException
+import com.teameetmeet.meetmeet.data.local.datastore.DataStoreHelper
+import com.teameetmeet.meetmeet.data.network.api.AuthApi
+import com.teameetmeet.meetmeet.data.network.entity.RefreshAccessTokenRequest
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+class TokenRepository @Inject constructor(
+    private val dataStoreHelper: DataStoreHelper,
+    private val authApi: AuthApi
+) {
+    suspend fun refreshAccessToken(): String {
+        val token = dataStoreHelper.getRefreshToken().first() ?: throw NoDataException()
+        try {
+            val response = authApi.refreshAccessToken(RefreshAccessTokenRequest(token))
+            dataStoreHelper.storeAppToken(response.accessToken, response.refreshToken)
+            return response.accessToken
+        } catch (e: Exception) {
+            throw ExpiredRefreshTokenException()
+        }
+    }
+
+    suspend fun getAccessToken(): String {
+        return dataStoreHelper.getAppToken().first() ?: throw NoDataException()
+    }
+
+}

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/UserRepository.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/UserRepository.kt
@@ -21,7 +21,7 @@ class UserRepository @Inject constructor(
         return flowOf(true)
             .map {
                 val token = dataStore.getAppToken().first() ?: throw NoDataException()
-                val result = userApi.getUserProfile("Bearer $token")
+                val result = userApi.getUserProfile()
                 result
             }.onEach {
                 fetchUserProfile(it)

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/di/RepositoryModule.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/di/RepositoryModule.kt
@@ -4,6 +4,7 @@ import com.teameetmeet.meetmeet.data.datasource.LocalCalendarDataSource
 import com.teameetmeet.meetmeet.data.datasource.RemoteCalendarDataSource
 import com.teameetmeet.meetmeet.data.local.database.dao.EventDao
 import com.teameetmeet.meetmeet.data.local.datastore.DataStoreHelper
+import com.teameetmeet.meetmeet.data.network.api.AuthApi
 import com.teameetmeet.meetmeet.data.network.api.EventStoryApi
 import com.teameetmeet.meetmeet.data.network.api.LoginApi
 import com.teameetmeet.meetmeet.data.network.api.UserApi
@@ -11,6 +12,7 @@ import com.teameetmeet.meetmeet.data.repository.CalendarRepository
 import com.teameetmeet.meetmeet.data.repository.EventStoryRepository
 import com.teameetmeet.meetmeet.data.repository.LoginRepository
 import com.teameetmeet.meetmeet.data.repository.SettingRepository
+import com.teameetmeet.meetmeet.data.repository.TokenRepository
 import com.teameetmeet.meetmeet.data.repository.UserRepository
 import dagger.Module
 import dagger.Provides
@@ -56,4 +58,11 @@ class RepositoryModule {
     fun provideSettingRepository(
         dataStore: DataStoreHelper
     ) = SettingRepository(dataStore)
+
+    @Singleton
+    @Provides
+    fun provideTokenRepository(
+        dataStore: DataStoreHelper,
+        authApi: AuthApi
+    ) = TokenRepository(dataStore, authApi)
 }


### PR DESCRIPTION
- access Token 만료 시 refresh token으로 갱신하여 새로 요청하도록 구현

## 개요

- authorization이 필요한 요청에 자동으로 header를 넣어주는 기능 구현
- access token이 만료되면 refresh token으로 갱신 후 다시 요청 기능 구현

- 안드로이드 페어프로그래밍을 함께 하고 서버 분들이 테스트를 함께 진행.
