### PR TITLE
feat: 토큰 만료 에러 코드 변경 (418 ImATeapot)

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -73,6 +73,17 @@ export class AuthController {
   @ApiOperation({
     summary: 'access token 검증 API',
   })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        accessToken: {
+          type: 'string',
+          description: 'access token이 유효한지 검증한다.',
+        },
+      },
+    },
+  })
   checkAccessToken(@Body('token') token: string) {
     return this.authService.verifyToken(token);
   }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -69,11 +69,11 @@ export class AuthController {
     return this.authService.refresh(refreshToken);
   }
 
-  @Get('check/token')
+  @Post('check/token')
   @ApiOperation({
     summary: 'access token 검증 API',
   })
-  checkAccessToken(@Query('token') token: string) {
+  checkAccessToken(@Body('token') token: string) {
     return this.authService.verifyToken(token);
   }
 

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -16,7 +16,7 @@ import { LocalStrategy } from './local.strategy';
       useFactory: async (configService: ConfigService) => ({
         secret: configService.get('JWT_SECRET_KEY'),
         signOptions: {
-          expiresIn: '30m',
+          expiresIn: '1m',
         },
       }),
       inject: [ConfigService],

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -114,13 +114,12 @@ export class AuthService {
       const payload = this.jwtService.verify(token, {
         secret: this.configService.get<string>('JWT_SECRET_KEY'),
       });
-      return {
-        isVerified: !this.isExpired(payload.exp),
-      };
+
+      if (this.isExpired(payload.exp)) {
+        throw new ImATeapotException('Access token is expired.');
+      }
     } catch (err) {
-      return {
-        isVerified: false,
-      };
+      throw new ImATeapotException('Invalid access token');
     }
   }
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ImATeapotException,
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
@@ -68,21 +69,26 @@ export class AuthService {
   }
 
   async refresh(refreshToken: string) {
-    const payload = this.jwtService.verify(refreshToken, {
-      secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
-    });
+    try {
+      const payload = this.jwtService.verify(refreshToken, {
+        secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
+      });
+      // TODO: refresh token db 검증
+      const user = await this.userService.findUserByEmail(payload.email);
 
-    // TODO: refresh token db 검증
-    const user = await this.userService.findUserByEmail(payload.email);
+      if (!user) {
+        throw new UnauthorizedException('Invalid User');
+      }
 
-    if (!user) {
-      throw new UnauthorizedException('Invalid User');
+      return {
+        accessToken: await this.generateAccessToken(user),
+        refreshToken: await this.generateRefreshToken(user),
+      };
+    } catch (err) {
+      if (err instanceof Error && err.name === 'TokenExpiredError') {
+        throw new ImATeapotException('Refresh token is expired.');
+      }
     }
-
-    return {
-      accessToken: await this.generateAccessToken(user),
-      refreshToken: await this.generateRefreshToken(user),
-    };
   }
 
   async generateAccessToken(user: User): Promise<string> {


### PR DESCRIPTION
## 설명

<!-- 

- 현재 Pr 설명 

-->

다른 401 unauthorized 에러와 구분을 위해 token 만료 에러 코드를 418로 변경했습니다.
refresh token 만료 시 에러 처리 부분을 추가했습니다.