### PR TITLE
Feature/backend/#33 delete feed: 피드 삭제 API 및 토큰 에러 418로 통일

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -88,6 +88,7 @@ export class AuthService {
       if (err instanceof Error && err.name === 'TokenExpiredError') {
         throw new ImATeapotException('Refresh token is expired.');
       }
+      throw new ImATeapotException('Invalid token');
     }
   }
 

--- a/backend/src/auth/jwt-auth.guard.ts
+++ b/backend/src/auth/jwt-auth.guard.ts
@@ -1,5 +1,19 @@
-import { Injectable } from '@nestjs/common';
+import { ImATeapotException, Injectable } from '@nestjs/common';
+import { TokenExpiredError } from '@nestjs/jwt';
 import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  handleRequest<User>(err: Error, user: User): User {
+    if (err instanceof TokenExpiredError) {
+      throw new ImATeapotException('Access token is expired.');
+    }
+    if (!user) {
+      throw new ImATeapotException('Invalid token.');
+    }
+    if (err instanceof Error) {
+      throw new ImATeapotException(err.message);
+    }
+    return user;
+  }
+}

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -1,13 +1,10 @@
-import {
-  ImATeapotException,
-  Injectable,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 import { User } from 'src/user/entities/user.entity';
 import { UserService } from 'src/user/user.service';
+import { TokenExpiredError } from '@nestjs/jwt';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -30,7 +27,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     }
 
     if (exp < new Date().getTime() / 1000) {
-      throw new ImATeapotException('Access token is expired.');
+      throw new TokenExpiredError('Access token is expired.', new Date(exp));
     }
 
     const user: User | null = await this.userService.findUserByEmail(email);

--- a/backend/src/comment/entities/comment.entity.ts
+++ b/backend/src/comment/entities/comment.entity.ts
@@ -5,7 +5,7 @@ import { User } from 'src/user/entities/user.entity';
 
 @Entity()
 export class Comment extends commonEntity {
-  @ManyToOne(() => Feed, { nullable: false })
+  @ManyToOne(() => Feed, { nullable: false, onDelete: 'CASCADE' })
   feed: Feed;
 
   @ManyToOne(() => User, { nullable: false })

--- a/backend/src/content/content.service.ts
+++ b/backend/src/content/content.service.ts
@@ -45,4 +45,8 @@ export class ContentService {
     await this.contentRepository.update(id, updatedContent);
     return await this.contentRepository.findOne({ where: { id } });
   }
+
+  async softDeleteContent(idList: number[]) {
+    await this.contentRepository.softDelete(idList);
+  }
 }

--- a/backend/src/feed/dto/feed-response.dto.ts
+++ b/backend/src/feed/dto/feed-response.dto.ts
@@ -16,7 +16,7 @@ export class FeedResponseDto {
       memo: feed.memo ?? null,
       author: feed.author,
       contents: feed.feedContents.map((feedContent) => feedContent.content),
-      comments: [], // TODO: comment 추가
+      comments: feed.comments, // TODO: comment 추가
     };
   }
 }

--- a/backend/src/feed/entities/feed.entity.ts
+++ b/backend/src/feed/entities/feed.entity.ts
@@ -10,6 +10,9 @@ export class Feed extends commonEntity {
   @Column()
   eventId: number;
 
+  @Column()
+  authorId: number;
+
   @ManyToOne(() => User, { nullable: false })
   author: User;
 
@@ -22,6 +25,8 @@ export class Feed extends commonEntity {
   @OneToMany(() => FeedContent, (feedContent) => feedContent.feed)
   feedContents: FeedContent[];
 
-  @OneToMany(() => Comment, (comment) => comment.feed)
+  @OneToMany(() => Comment, (comment) => comment.feed, {
+    cascade: ['soft-remove'],
+  })
   comments: Comment[];
 }

--- a/backend/src/feed/feed.service.ts
+++ b/backend/src/feed/feed.service.ts
@@ -2,9 +2,11 @@ import {
   BadRequestException,
   Injectable,
   NotFoundException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ContentService } from 'src/content/content.service';
+import { AuthorityEnum } from 'src/event-member/entities/authority.enum';
 import { EventMemberService } from 'src/event-member/event-member.service';
 import { User } from 'src/user/entities/user.entity';
 import { Repository } from 'typeorm';
@@ -61,10 +63,10 @@ export class FeedService {
         'feed.author',
         'fc.contentId',
         'fc.content',
-        // 'feed.comments',
+        'comment',
       ])
       .leftJoin('feed.feedContents', 'fc')
-      // .leftJoinAndSelect('feed.comments', 'comment')
+      .leftJoin('feed.comments', 'comment')
       .leftJoinAndSelect('feed.author', 'author')
       .leftJoinAndSelect('fc.content', 'content')
       .where('feed.id = :id', { id })
@@ -77,5 +79,44 @@ export class FeedService {
     return FeedResponseDto.of(feed);
   }
 
-  async deleteFeed(user: User, id: number) {}
+  async deleteFeed(user: User, id: number) {
+    const feed = await this.feedRepository
+      .createQueryBuilder('feed')
+      .select([
+        'feed.id',
+        'feed.authorId',
+        'feed.memo',
+        'fc.contentId',
+        'comment',
+      ])
+      .leftJoin('feed.feedContents', 'fc')
+      .leftJoin('feed.comments', 'comment')
+      .leftJoin('fc.content', 'content')
+      .where('feed.id = :id', { id })
+      .getOne();
+
+    if (!feed) {
+      throw new NotFoundException();
+    }
+
+    if (feed.author.id !== user.id) {
+      const authority =
+        await this.eventMemberSercive.getAuthorityOfUserByEventId(
+          feed.eventId,
+          user.id,
+        );
+
+      if (authority !== AuthorityEnum.OWNER) {
+        throw new UnauthorizedException('피드 삭제 권한이 없습니다.');
+      }
+    }
+
+    if (feed.feedContents.length) {
+      this.contentService.softDeleteContent(
+        feed.feedContents.map((feedContent) => feedContent.contentId),
+      );
+    }
+
+    this.feedRepository.softRemove(feed);
+  }
 }

--- a/backend/src/feed/feed.service.ts
+++ b/backend/src/feed/feed.service.ts
@@ -99,7 +99,7 @@ export class FeedService {
       throw new NotFoundException();
     }
 
-    if (feed.author.id !== user.id) {
+    if (feed.authorId !== user.id) {
       const authority =
         await this.eventMemberSercive.getAuthorityOfUserByEventId(
           feed.eventId,
@@ -117,6 +117,6 @@ export class FeedService {
       );
     }
 
-    this.feedRepository.softRemove(feed);
+    await this.feedRepository.softRemove(feed);
   }
 }


### PR DESCRIPTION
## 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

Issue: #33 
related pr: #134 

## 설명

<!-- 

- 현재 Pr 설명 

-->

### 피드 삭제 기능 구현

- 피드가 삭제될 때 `comment`도 함께 삭제해 주는 부분을 `cascade`를 사용해서 구현해봤습니다!

```ts
export class Comment extends commonEntity {
  @ManyToOne(() => Feed, { nullable: false, onDelete: 'CASCADE' })
  feed: Feed;
  // ...
}
```

```ts
export class Feed extends commonEntity {
  // ...
  @OneToMany(() => Comment, (comment) => comment.feed, {
    cascade: ['soft-remove'],
  })
  comments: Comment[];
}
```

`feed`가 삭제될 때 `comment`의 `deletedAt`도 함께 업데이트하고 싶다면 `softDelete()`가 아닌 `softRemove()`를 사용해야 했습니다!

```ts
await this.feedRepository.softRemove(feed);
```

- `softDelete()` : 조건을 바탕으로 엔티티를 삭제, save()와 달리 cascades와 relations 등이 포함되지 않고 빠르고 효율적인 쿼리 실행
- `softRemove()` : 주어진 엔티티를 삭제


### 토큰 관련 에러 처리

- 어제 `access token`에 jwt 형태가 아닌 이상한 값이 들어간 경우에는 `401` 에러를 응답하는 현상을 수정했습니다.

```ts
async validate(payload: { email: string; exp: number }): Promise<User> {
    const { email, exp } = payload;

    if (!email) {
      throw new UnauthorizedException();
    }

    if (exp < new Date().getTime() / 1000) {
      throw new TokenExpiredError('Access token is expired.', new Date(exp));
    }

    const user: User | null = await this.userService.findUserByEmail(email);
    if (!user) {
      throw new UnauthorizedException();
    }
    return user;
  }
```

`JwtStrategy`는 그대로 두고 `JwtAuthGuard`에서 `handleRequest()`를 통해 에러 처리를 해줄 수 있도록 했습니다.

```ts
@Injectable()
export class JwtAuthGuard extends AuthGuard('jwt') {
  handleRequest<User>(err: Error, user: User): User {
    if (err instanceof TokenExpiredError) {
      throw new ImATeapotException('Access token is expired.');
    }
    if (!user) {
      throw new ImATeapotException('Invalid token.');
    }
    if (err instanceof Error) {
      throw new ImATeapotException(err.message);
    }
    return user;
  }
}

```

## 고민거리 

<!-- (Optional) 의견 받고싶은 부분 있으면 적어두기

### Q. ui 이벤트 처리를 어디서 해야할 지 모르겠어요...

-->

현재는 content 테이블에 이미지, 영상에 대한 메타데이터를 저장하고 있는데, object storage를 이용하게 된다면 content table의 존재 의미가 사라질 것 같습니다..! 그냥 feedContent 테이블에 content_id 대신 경로를 입력해줘도 될까요?