### PR TITLE
Feature/backend/#16 event story: 일정 공지 등록, 삭제 API

### DIFF
--- a/backend/src/content/content.service.ts
+++ b/backend/src/content/content.service.ts
@@ -15,10 +15,7 @@ export class ContentService {
     private readonly objectStorage: ObjectStorage,
     private readonly configService: ConfigService,
   ) {
-    this.locationPrefix = configService.get(
-      'CONTENT_PREFIX',
-      'https://kr.object.ncloudstorage.com/meetmeet/',
-    );
+    this.locationPrefix = configService.get('CONTENT_PREFIX', '');
   }
 
   async createContent(file: Express.Multer.File, dir: string) {
@@ -96,6 +93,6 @@ export class ContentService {
   }
 
   generateFilePath(dir: string, fileName: string) {
-    return `${dir}/${uuidv4().substring(0, 18)}${extname(fileName)}`;
+    return `${dir}/${uuidv4().split('-').slice(2).join()}${extname(fileName)}`;
   }
 }

--- a/backend/src/event/entities/event.entity.ts
+++ b/backend/src/event/entities/event.entity.ts
@@ -23,7 +23,7 @@ export class Event extends commonEntity {
   isJoinable: boolean;
 
   @Column({ type: 'varchar', length: 255, nullable: true })
-  announcement: string;
+  announcement: string | null;
 
   @Column({ nullable: true })
   repeatPolicyId: number;

--- a/backend/src/event/event.controller.ts
+++ b/backend/src/event/event.controller.ts
@@ -164,6 +164,34 @@ export class EventController {
   }
 
   @UseGuards(JwtAuthGuard)
+  @Patch('/:eventId/announcement')
+  @ApiOperation({
+    summary: '일정 공지 수정 API',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        announcement: {
+          type: 'string',
+        },
+      },
+    },
+  })
+  async updateEventAnnouncement(
+    @GetUser() user: User,
+    @Param('eventId', new ParseIntPipe({ errorHttpStatusCode: 400 }))
+    eventId: number,
+    @Body('announcement') announcement: string,
+  ) {
+    return await this.eventService.updateEventAnnouncement(
+      user,
+      eventId,
+      announcement,
+    );
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Patch('/:eventId')
   @ApiOperation({
     summary: '일정 수정 API',

--- a/backend/src/event/event.service.ts
+++ b/backend/src/event/event.service.ts
@@ -4,6 +4,7 @@ import {
   HttpStatus,
   Injectable,
   NotFoundException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { FindOperator, Raw, Repository } from 'typeorm';
@@ -610,6 +611,25 @@ export class EventService {
       }
     }
     // Todo 업데이트 한거 줘야한다.
+  }
+
+  async updateEventAnnouncement(
+    user: User,
+    eventId: number,
+    announcement: string,
+  ) {
+    const authority = await this.eventMemberService.getAuthorityOfUserByEventId(
+      eventId,
+      user.id,
+    );
+
+    if (!authority || authority !== 'OWNER') {
+      throw new UnauthorizedException('일정 공지 권한이 없습니다.');
+    }
+
+    await this.eventRepository.update(eventId, {
+      announcement: announcement ?? null,
+    });
   }
 
   async searchEvent(user: User, searchEventDto: SearchEventDto) {


### PR DESCRIPTION
## 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

Issue: #16 

## 설명

<!-- 

- 현재 Pr 설명 

-->

일정에 공지를 등록/수정하고 삭제할 수 있습니다.
announcement에 `null`을 보내면 공지가 삭제됩니다.


```
PATCH /event/:id/announcement

{
  "announcement": "New announcement!"
}
```

+) #159 의 피드백 반영
