### PR TITLE
Feature/android/#28 #55: 일정 추가 response 처리 및 알림 설정, 프로필 설정 API 분리

### DIFF
--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/datasource/RemoteCalendarDataSource.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/datasource/RemoteCalendarDataSource.kt
@@ -35,10 +35,19 @@ class RemoteCalendarDataSource @Inject constructor(private val api: CalendarApi)
             }
     }
 
-    fun addEvent(addEventRequest: AddEventRequest): Flow<List<EventResponse>> {
+    fun addSingleEvent(addEventRequest: AddEventRequest): Flow<EventResponse> {
         return flowOf(true)
             .map {
-                api.addEvent(addEventRequest).events
+                api.addSingleEvent(addEventRequest).event
+            }.catch {
+                throw it
+            }
+    }
+
+    fun addRepeatEvent(addEventRequest: AddEventRequest): Flow<List<EventResponse>> {
+        return flowOf(true)
+            .map {
+                api.addRepeatEvent(addEventRequest).events
             }.catch {
                 throw it
             }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/datasource/RemoteCalendarDataSource.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/datasource/RemoteCalendarDataSource.kt
@@ -35,10 +35,12 @@ class RemoteCalendarDataSource @Inject constructor(private val api: CalendarApi)
             }
     }
 
-    fun addEvent(addEventRequest: AddEventRequest): Flow<Unit> {
+    fun addEvent(addEventRequest: AddEventRequest): Flow<List<EventResponse>> {
         return flowOf(true)
             .map {
-                api.addEvent(addEventRequest)
+                api.addEvent(addEventRequest).events
+            }.catch {
+                throw it
             }
     }
 }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/CalendarApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/CalendarApi.kt
@@ -2,6 +2,7 @@ package com.teameetmeet.meetmeet.data.network.api
 
 import com.teameetmeet.meetmeet.data.network.entity.AddEventRequest
 import com.teameetmeet.meetmeet.data.network.entity.Events
+import com.teameetmeet.meetmeet.data.network.entity.SingleEvent
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -22,7 +23,12 @@ interface CalendarApi {
     ): Events
 
     @POST("event")
-    suspend fun addEvent(
+    suspend fun addSingleEvent(
+        @Body addEventRequest: AddEventRequest
+    ): SingleEvent
+
+    @POST("event")
+    suspend fun addRepeatEvent(
         @Body addEventRequest: AddEventRequest
     ): Events
 }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/CalendarApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/CalendarApi.kt
@@ -24,5 +24,5 @@ interface CalendarApi {
     @POST("event")
     suspend fun addEvent(
         @Body addEventRequest: AddEventRequest
-    )
+    ): Events
 }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/UserApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/UserApi.kt
@@ -2,9 +2,9 @@ package com.teameetmeet.meetmeet.data.network.api
 
 import com.teameetmeet.meetmeet.data.model.UserProfile
 import com.teameetmeet.meetmeet.data.network.entity.AvailableResponse
+import com.teameetmeet.meetmeet.data.network.entity.NicknameChangeRequest
 import com.teameetmeet.meetmeet.data.network.entity.PasswordChangeRequest
 import okhttp3.MultipartBody
-import okhttp3.RequestBody
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -27,10 +27,12 @@ interface UserApi {
     @PATCH("user/account")
     suspend fun patchPassword(@Body passwordChangeRequest: PasswordChangeRequest): UserProfile
 
+    @PATCH("user/nickname")
+    suspend fun patchNickname(@Body nicknameChangeRequest: NicknameChangeRequest)
+
     @Multipart
-    @PATCH("user/info")
-    suspend fun updateUserProfile(
-        @Part("nickname") nickname: RequestBody,
-        @Part profile: MultipartBody.Part?,
-    ): UserProfile
+    @PATCH("user/profile")
+    suspend fun updateProfileImage(
+        @Part profile: MultipartBody.Part,
+    )
 }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/entity/EventResponse.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/entity/EventResponse.kt
@@ -1,23 +1,41 @@
 package com.teameetmeet.meetmeet.data.network.entity
 
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.teameetmeet.meetmeet.data.model.EventMember
 
 @JsonClass(generateAdapter = true)
 data class EventResponse(
+    @Json(name = "id")
     val id: Int,
+    @Json(name = "title")
     val title: String,
+    @Json(name = "startDate")
     val startDate: String,
+    @Json(name = "endDate")
     val endDate: String,
+    @Json(name = "eventMembers")
     val eventMembers: List<EventMember> = listOf(),
+    @Json(name = "authority")
     val authority: String = "",
+    @Json(name = "repeatPolicyId")
     val repeatPolicyId: Int? = null,
+    @Json(name = "isJoinable")
     val isJoinable: Boolean = false,
+    @Json(name = "alarmMinutes")
     val alarmMinutes: Int = -1,
+    @Json(name = "color")
     val color: Int = -39579
 )
 
 @JsonClass(generateAdapter = true)
 data class Events(
+    @Json(name = "events")
     val events: List<EventResponse>
+)
+
+@JsonClass(generateAdapter = true)
+data class SingleEvent(
+    @Json(name = "event")
+    val event: EventResponse
 )

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/entity/EventResponse.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/entity/EventResponse.kt
@@ -9,12 +9,12 @@ data class EventResponse(
     val title: String,
     val startDate: String,
     val endDate: String,
-    val eventMembers: List<EventMember>,
-    val authority: String,
-    val repeatPolicyId: Int?,
-    val isJoinable: Boolean,
-    val alarmMinutes: Int,
-    val color: Int
+    val eventMembers: List<EventMember> = listOf(),
+    val authority: String = "",
+    val repeatPolicyId: Int? = null,
+    val isJoinable: Boolean = false,
+    val alarmMinutes: Int = -1,
+    val color: Int = -39579
 )
 
 @JsonClass(generateAdapter = true)

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/entity/NicknameChangeRequest.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/entity/NicknameChangeRequest.kt
@@ -1,0 +1,10 @@
+package com.teameetmeet.meetmeet.data.network.entity
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class NicknameChangeRequest(
+    @Json(name = "nickname")
+    val nickname: String
+)

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/CalendarRepository.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/CalendarRepository.kt
@@ -43,7 +43,7 @@ class CalendarRepository @Inject constructor(
         repeatEndDate: String,
         color: EventColor,
         alarm: EventNotification
-    ): Flow<Unit> {
+    ): Flow<List<EventResponse>> {
         val request = AddEventRequest(
             title = title,
             startDate = startDate,
@@ -59,6 +59,7 @@ class CalendarRepository @Inject constructor(
         )
         return remoteCalendarDataSource.addEvent(request)
             .catch {
+                throw it
             }
     }
 

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/CalendarRepository.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/CalendarRepository.kt
@@ -31,7 +31,7 @@ class CalendarRepository @Inject constructor(
         localCalendarDataSource.deleteAll()
     }
 
-    fun addEvent(
+    fun addRepeatEvent(
         title: String,
         startDate: String,
         endDate: String,
@@ -57,7 +57,39 @@ class CalendarRepository @Inject constructor(
             repeatFrequency = repeatFrequency,
             repeatEndDate = repeatEndDate
         )
-        return remoteCalendarDataSource.addEvent(request)
+        return remoteCalendarDataSource.addRepeatEvent(request)
+            .catch {
+                throw it
+            }
+    }
+
+    fun addSingleEvent(
+        title: String,
+        startDate: String,
+        endDate: String,
+        isJoinable: Boolean,
+        isVisible: Boolean,
+        memo: String,
+        repeatTerm: String?,
+        repeatFrequency: Int,
+        repeatEndDate: String,
+        color: EventColor,
+        alarm: EventNotification
+    ): Flow<EventResponse> {
+        val request = AddEventRequest(
+            title = title,
+            startDate = startDate,
+            endDate = endDate,
+            isJoinable = isJoinable,
+            isVisible = isVisible,
+            alarmMinutes = alarm.minutes,
+            memo = memo.ifEmpty { null },
+            color = color.value,
+            repeatTerm = repeatTerm,
+            repeatFrequency = repeatFrequency,
+            repeatEndDate = repeatEndDate
+        )
+        return remoteCalendarDataSource.addSingleEvent(request)
             .catch {
                 throw it
             }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/UserRepository.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/UserRepository.kt
@@ -4,6 +4,7 @@ import com.teameetmeet.meetmeet.data.NoDataException
 import com.teameetmeet.meetmeet.data.local.datastore.DataStoreHelper
 import com.teameetmeet.meetmeet.data.model.UserProfile
 import com.teameetmeet.meetmeet.data.network.api.UserApi
+import com.teameetmeet.meetmeet.data.network.entity.NicknameChangeRequest
 import com.teameetmeet.meetmeet.data.network.entity.PasswordChangeRequest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -96,11 +97,24 @@ class UserRepository @Inject constructor(
             }
     }
 
-    fun patchUserProfile(image: File?, nickname: String): Flow<UserProfile> {
+    fun patchNickname(nickname: String): Flow<Unit> {
+        return flowOf(true)
+            .map {
+                userApi.patchNickname(NicknameChangeRequest(nickname))
+            }.catch {
+                throw it
+            }
+    }
+
+    fun patchProfileImage(image: File?): Flow<Unit> {
         return flowOf(true)
             .map {
                 val profileImageRequest = if (image == null) {
-                    null
+                    MultipartBody.Part.createFormData(
+                        "profile",
+                        "",
+                        "".toRequestBody("text/plain".toMediaType())
+                    )
                 } else {
                     MultipartBody.Part.createFormData(
                         "profile",
@@ -108,10 +122,9 @@ class UserRepository @Inject constructor(
                         image.asRequestBody()
                     )
                 }
-                val nicknameRequest = nickname.toRequestBody("text/plain".toMediaType())
-                val response = userApi.updateUserProfile(nicknameRequest, profileImageRequest)
-                fetchUserProfile(response)
-                response
+                userApi.updateProfileImage(profileImageRequest)
+            }.catch {
+                throw it
             }
     }
 }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/addevent/AddEventViewModel.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/addevent/AddEventViewModel.kt
@@ -48,8 +48,12 @@ class AddEventViewModel @Inject constructor(
     )
     val event: SharedFlow<AddEventUiEvent> = _event
 
+    private val _showPlaceholder: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val showPlaceholder: StateFlow<Boolean> = _showPlaceholder
+
     fun eventSave() {
         viewModelScope.launch {
+            _showPlaceholder.update { true }
             if (checkEvent()) {
                 val startDateTime =
                     _uiState.value.startDate.plusHours(_uiState.value.startTime.hour.toLong())
@@ -80,6 +84,7 @@ class AddEventViewModel @Inject constructor(
                         alarm = alarm,
                     ).catch {
                         _event.emit(AddEventUiEvent.ShowMessage(R.string.add_event_err_fail))
+                        _showPlaceholder.update { false }
                     }.collectLatest { events ->
                         events.take(MAX_ALARM_COUNT).forEach { event ->
                             val currentTime = LocalDateTime.now().toLong()
@@ -98,6 +103,7 @@ class AddEventViewModel @Inject constructor(
                             }
                         }
                         _event.emit(AddEventUiEvent.FinishAddEventActivity)
+                        _showPlaceholder.update { false }
                     }
                 }
             }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/setting/profile/SettingProfileFragment.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/setting/profile/SettingProfileFragment.kt
@@ -46,16 +46,21 @@ class SettingProfileFragment :
         binding.vm = viewModel
         setTopAppBar(args.isFirstSignIn)
         setPhotoPicker()
-        collectViewModelEvent()
+        collectViewModelEvent(args.isFirstSignIn)
     }
 
-    private fun collectViewModelEvent() {
+    private fun collectViewModelEvent(isFirstSignIn: Boolean) {
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.event.collectLatest { event ->
                     when (event) {
                         is SettingProfileUiEvent.NavigateToSettingHomeFragment -> {
-                            findNavController().popBackStack()
+                            if (isFirstSignIn) {
+                                findNavController().navigate(SettingProfileFragmentDirections.actionSettingProfileFragmentToHomeActivity())
+                                requireActivity().finish()
+                            } else {
+                                findNavController().popBackStack()
+                            }
                         }
 
                         is SettingProfileUiEvent.ShowMessage -> {

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/setting/profile/SettingProfileUiState.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/setting/profile/SettingProfileUiState.kt
@@ -5,8 +5,8 @@ import com.teameetmeet.meetmeet.data.model.UserProfile
 
 data class SettingProfileUiState(
     val currentUserProfile: UserProfile = UserProfile(null, "", ""),
-    val profileImage: Uri? = null,
+    val profileImage: Uri? = Uri.parse(""),
     val nickname: String = "",
     val duplicatedEnable: Boolean = false,
-    val nickNameState: NickNameState = NickNameState.Same,
+    val nickNameState: NickNameState = NickNameState.None,
 )

--- a/android/app/src/main/res/layout/activity_add_event.xml
+++ b/android/app/src/main/res/layout/activity_add_event.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
@@ -380,6 +381,33 @@
 
         </androidx.core.widget.NestedScrollView>
 
+        <View
+            android:id="@+id/view_loading_background"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@color/loading_background"
+            android:clickable="true"
+            android:focusable="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/layout_app_bar" />
+
+        <ProgressBar
+            android:id="@+id/progress_bar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.constraintlayout.widget.Group
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="@{vm.showPlaceholder ?View.VISIBLE:View.GONE}"
+            app:constraint_referenced_ids="view_loading_background, progress_bar"
+            tools:visibility="gone" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -100,6 +100,7 @@
     <string name="setting_password_change_fail">비밀번호 변경 실패</string>
     <string name="setting_profile_fail">프로필 변경 실패</string>
     <string name="setting_profile_set_default">기본 이미지로 변경</string>
+    <string name="setting_profile_network_error">프로필 정보를 가져올 수 없습니다</string>
 
     <string name="sign_up_duplicate_check_complete">중복확인 완료</string>
     <string name="sign_up_duplicate_check_fail">중복된 이메일 입니다</string>


### PR DESCRIPTION
## 개요

- 이슈번호: #55 #28
- 일정 추가 response 처리 및 알림 설정
- 프로필 설정 API 분리
- Close: #55 
- Close: #28 

## 설명

- 일정 추가 response 처리
  - 기존의 Events를 통해서 반복일정 처리
  - 추가로 SingleEvent 모델 생성하여 단일 일정에 대해서 처리
- 프로필 API 분리
  - 닉네임 변경 API와 프로필 이미지 API 로 분리하여 처리

## 고민거리 
### Q. 프로필 변경 API를 연결하면서 두개의 Flow를 처리해야하는데 변경하지 않는 경우 호출을 하지 않기 때문에 하나의 Flow로 어떤 방법으로 합쳐서 에러 처리를 해야할 지 모르겠당..

## 구현사진
![GIF](https://github.com/boostcampwm2023/and08-meetmeet/assets/87304360/afa50704-08da-4984-a2e8-2fde529fdfea)
