### PR TITLE
Feature/android/#16 edit announcement : 일정 공지 수정/ 삭제

### DIFF
--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/EventStoryApi.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/api/EventStoryApi.kt
@@ -5,9 +5,9 @@ import com.teameetmeet.meetmeet.data.model.FeedDetail
 import com.teameetmeet.meetmeet.data.model.FollowUsers
 import com.teameetmeet.meetmeet.data.network.entity.AddEventRequest
 import com.teameetmeet.meetmeet.data.network.entity.AddFeedCommentRequest
+import com.teameetmeet.meetmeet.data.network.entity.AnnouncementRequest
 import com.teameetmeet.meetmeet.data.network.entity.EventInviteRequest
 import com.teameetmeet.meetmeet.data.network.entity.EventStoryDetailResponse
-import com.teameetmeet.meetmeet.data.network.entity.KakaoLoginRequest
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.http.Body
@@ -23,13 +23,13 @@ import retrofit2.http.Query
 interface EventStoryApi {
 
     @GET("/event/{event_id}/feeds")
-    suspend fun getStory(@Path("event_id") id: String): EventStory
+    suspend fun getStory(@Path("event_id") id: Int): EventStory
 
     @GET("/event/{eventId}")
-    suspend fun getStoryDetail(@Path("eventId") id: String): EventStoryDetailResponse
+    suspend fun getStoryDetail(@Path("eventId") id: Int): EventStoryDetailResponse
 
-    @POST()
-    suspend fun editNotification(@Body singleStringRequest: KakaoLoginRequest)
+    @PATCH("event/{eventId}/announcement")
+    suspend fun editNotification(@Path("eventId") eventId: Int, @Body announcementRequest: AnnouncementRequest)
 
     @POST("event/schedule/join/{eventId}")
     suspend fun joinEventStory(@Path("eventId") eventId: Int)

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/entity/AnnouncementRequest.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/entity/AnnouncementRequest.kt
@@ -6,5 +6,5 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class AnnouncementRequest(
     @Json(name = "announcement")
-    val announcement: String
+    val announcement: String?
 )

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/entity/AnnouncementRequest.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/network/entity/AnnouncementRequest.kt
@@ -1,0 +1,10 @@
+package com.teameetmeet.meetmeet.data.network.entity
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class AnnouncementRequest(
+    @Json(name = "announcement")
+    val announcement: String
+)

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/EventStoryRepository.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/EventStoryRepository.kt
@@ -7,8 +7,8 @@ import com.teameetmeet.meetmeet.data.model.UserStatus
 import com.teameetmeet.meetmeet.data.network.api.EventStoryApi
 import com.teameetmeet.meetmeet.data.network.entity.AddEventRequest
 import com.teameetmeet.meetmeet.data.network.entity.AddFeedCommentRequest
+import com.teameetmeet.meetmeet.data.network.entity.AnnouncementRequest
 import com.teameetmeet.meetmeet.data.network.entity.EventInviteRequest
-import com.teameetmeet.meetmeet.data.network.entity.KakaoLoginRequest
 import com.teameetmeet.meetmeet.data.toException
 import com.teameetmeet.meetmeet.presentation.model.EventColor
 import com.teameetmeet.meetmeet.presentation.model.EventNotification
@@ -29,7 +29,7 @@ class EventStoryRepository @Inject constructor(
     fun getEventStory(id: Int): Flow<EventStory> {
         return flowOf(true)
             .map {
-                eventStoryApi.getStory(id.toString())
+                eventStoryApi.getStory(id)
             }.catch {
                 throw it.toException()
             }
@@ -38,7 +38,7 @@ class EventStoryRepository @Inject constructor(
     fun getEventStoryDetail(id: Int): Flow<EventDetail> {
         return flowOf(Unit)
             .map {
-                eventStoryApi.getStoryDetail(id.toString()).result
+                eventStoryApi.getStoryDetail(id).result
             }.catch {
                 throw it.toException()
             }
@@ -92,10 +92,10 @@ class EventStoryRepository @Inject constructor(
             }
     }
 
-    fun editNotification(message: String): Flow<Unit> {
+    fun editNotification(eventId: Int, message: String): Flow<Unit> {
         return flowOf(true)
             .map {
-                eventStoryApi.editNotification(KakaoLoginRequest(message))
+                eventStoryApi.editNotification(eventId, AnnouncementRequest(message))
             }.catch {
                 throw it.toException()
             }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/EventStoryRepository.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/data/repository/EventStoryRepository.kt
@@ -92,7 +92,7 @@ class EventStoryRepository @Inject constructor(
             }
     }
 
-    fun editNotification(eventId: Int, message: String): Flow<Unit> {
+    fun editNotification(eventId: Int, message: String?): Flow<Unit> {
         return flowOf(true)
             .map {
                 eventStoryApi.editNotification(eventId, AnnouncementRequest(message))

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/EventStoryFragment.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/EventStoryFragment.kt
@@ -141,7 +141,12 @@ class EventStoryFragment : BaseFragment<FragmentEventStoryBinding>(R.layout.frag
 
     private fun showDialog(noti: String) {
         AlertDialog.Builder(requireContext()).apply {
-            setMessage(noti).create().show()
+            setTitle(R.string.event_story_title_event_notification)
+                .setMessage(noti)
+                .setNeutralButton(R.string.event_story_delete_event_notification) { _, _ ->
+                    viewModel.editNotification(null)
+                }
+                .create().show()
         }
     }
 

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/EventStoryViewModel.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/EventStoryViewModel.kt
@@ -101,13 +101,20 @@ class EventStoryViewModel @Inject constructor(
     }
 
 
-    override fun onSaveButtonClick(message: String) {
+    override fun onSaveButtonClick(message: String?) {
+        editNotification(message)
+    }
+
+    fun editNotification(message: String?) {
         viewModelScope.launch {
             eventStoryRepository.editNotification(eventStoryUiState.value.eventId, message).catch {
                 _event.emit(EventStoryEvent.ShowMessage(R.string.event_story_message_edit_noti_fail, it.message.orEmpty()))
             }.collect {
                 _eventStoryUiState.update {
                     it.copy(eventStory = eventStoryUiState.value.eventStory?.copy(announcement = message))
+                }
+                if(message == null) {
+                    _event.emit(EventStoryEvent.ShowMessage(R.string.event_story_message_notification_delete_success))
                 }
             }
         }

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/EventStoryViewModel.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/EventStoryViewModel.kt
@@ -103,7 +103,7 @@ class EventStoryViewModel @Inject constructor(
 
     override fun onSaveButtonClick(message: String) {
         viewModelScope.launch {
-            eventStoryRepository.editNotification(message).catch {
+            eventStoryRepository.editNotification(eventStoryUiState.value.eventId, message).catch {
                 _event.emit(EventStoryEvent.ShowMessage(R.string.event_story_message_edit_noti_fail, it.message.orEmpty()))
             }.collect {
                 _eventStoryUiState.update {

--- a/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/OnNotiChangeListener.kt
+++ b/android/app/src/main/java/com/teameetmeet/meetmeet/presentation/eventstory/eventstory/OnNotiChangeListener.kt
@@ -2,5 +2,5 @@ package com.teameetmeet.meetmeet.presentation.eventstory.eventstory
 
 interface OnNotiChangeListener {
 
-    fun onSaveButtonClick(message: String)
+    fun onSaveButtonClick(message: String?)
 }

--- a/android/app/src/main/res/layout/fragment_event_story.xml
+++ b/android/app/src/main/res/layout/fragment_event_story.xml
@@ -185,6 +185,7 @@
                     android:foreground="?attr/selectableItemBackgroundBorderless"
                     android:maxLines="3"
                     android:text="@{vm.eventStoryUiState.eventStory.announcement ?? @string/common_none}"
+                    android:clickable="@{vm.eventStoryUiState.eventStory.announcement != null}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="@id/event_story_tv_title_event_notification"
                     app:layout_constraintTop_toBottomOf="@id/event_story_tv_title_event_notification"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -125,6 +125,7 @@
     <string name="event_story_title_event_time">일정 시간</string>
     <string name="event_story_title_event_members">일정 멤버</string>
     <string name="event_story_title_event_notification">일정 공지</string>
+    <string name="event_story_delete_event_notification">공지 삭제</string>
     <string name="event_story_message_event_story_fail">스토리를 불러올 수 없습니다.\n%s</string>
     <string name="event_story_event_date">%1s - %2s</string>
     <string name="event_story_invite_fail">일정 초대 실패</string>
@@ -224,4 +225,5 @@
     <string name="feed_detail_comment_hint">댓글을 입력하세요</string>
     <string name="feed_detail_comment_amount">댓글 %d회</string>
     <string name="feed_detail_media_count">%d/%d</string>
+    <string name="event_story_message_notification_delete_success">일정 공지를 삭제하였습니다.</string>
 </resources>


### PR DESCRIPTION
## 개요


- 이슈번호: #16
- 일정 공지 수정/삭제 기능 구현


## 설명

- 일정 공지 수정 api  연결
- 일정 공지 dialog ui 변경
  - dialog 제목 추가
  - dialog 삭제 버튼 추가
  - 삭제 클릭 시 수정 api의 값을 null로 전달
  - 삭제 시 공지 클릭 불가하도록 변경 


## 구현사진

![event_notification](https://github.com/boostcampwm2023/and08-meetmeet/assets/59364681/97eeec94-adbc-4375-bb22-a2b6282a6ffd)



Closes #16
