### PR TITLE
Feature/backend/#28 create event: createEvent insert 성능 개선

### DIFF
--- a/backend/src/detail/detail.service.ts
+++ b/backend/src/detail/detail.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Detail } from './entities/detail.entity';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { CreateScheduleDto } from '../event/dto/createSchedule.dto';
 
 @Injectable()
@@ -24,14 +24,16 @@ export class DetailService {
   }
 
   async createDetailBulk(createScheduleDto: CreateScheduleDto, count: number) {
-    const detailArray = [];
-    for (let i = 0; i < count; i++) {
-      const detail = this.detailRepository.create({
+    const detailArray = [...new Array(count)].map(() =>
+      this.detailRepository.create({
         ...createScheduleDto,
-      });
-      detailArray.push(detail);
-    }
-    return await this.detailRepository.save(detailArray);
+      }),
+    );
+
+    const result = await this.detailRepository.insert(detailArray);
+    return await this.detailRepository.find({
+      where: { id: In(result.identifiers.map((identifier) => identifier.id)) },
+    });
   }
 
   async updateDetail(detail: Detail, createScheduleDto: CreateScheduleDto) {

--- a/backend/src/event/dto/event-story-response.dto.ts
+++ b/backend/src/event/dto/event-story-response.dto.ts
@@ -1,4 +1,3 @@
-import { NotFoundException } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
 import { Feed } from 'src/feed/entities/feed.entity';
 import { Event } from '../entities/event.entity';
@@ -27,10 +26,6 @@ export class EventStoryResponseDto extends EventResponse {
   announcement: string | null;
   @ApiProperty()
   repeatPolicyId: number | null;
-  @ApiProperty()
-  isVisible: boolean;
-  @ApiProperty()
-  memo: string | null;
   @ApiProperty({ type: EventFeed })
   feeds: EventFeed[];
 
@@ -38,12 +33,6 @@ export class EventStoryResponseDto extends EventResponse {
     const memberDetail = event.eventMembers.find(
       (eventMember) => eventMember.user?.id === userId,
     );
-
-    if (!memberDetail) {
-      throw new NotFoundException(
-        `Cannot find eventmember where eventId=${event.id} and userId=${userId}`,
-      );
-    }
 
     return {
       id: event.id,
@@ -54,11 +43,9 @@ export class EventStoryResponseDto extends EventResponse {
         Member.of(eventMember),
       ),
       announcement: event.announcement ?? null,
-      authority: memberDetail.authority.displayName ?? null,
+      authority: memberDetail?.authority.displayName ?? null,
       repeatPolicyId: event.repeatPolicyId ?? null,
       isJoinable: event.isJoinable ? true : false,
-      isVisible: memberDetail.detail.isVisible ? true : false,
-      memo: memberDetail.detail?.memo ?? null,
       feeds: event.feeds.map((feed) => EventFeed.of(feed)),
     };
   }

--- a/backend/src/event/entities/repeatPolicy.entity.ts
+++ b/backend/src/event/entities/repeatPolicy.entity.ts
@@ -2,6 +2,13 @@ import { Column, Entity, OneToMany } from 'typeorm';
 import { commonEntity } from 'src/common/common.entity';
 import { Event } from './event.entity';
 
+export const RepeatType = {
+  DAY: 'repeatDay',
+  WEEK: 'repeatWeek',
+  MONTH: 'repeatMonth',
+  YEAR: 'repeatYear',
+} as const;
+
 @Entity()
 export class RepeatPolicy extends commonEntity {
   @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })

--- a/backend/src/event/exception/event.exception.ts
+++ b/backend/src/event/exception/event.exception.ts
@@ -82,3 +82,30 @@ export class NotInviteReceiverException extends HttpException {
     super('초대 받은 사람이 아닙니다.', HttpStatus.BAD_REQUEST);
   }
 }
+
+export class createEventFailException extends HttpException {
+  constructor() {
+    super(
+      '이벤트 생성 중 오류가 발생했습니다.',
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+}
+
+export class updateEventFailException extends HttpException {
+  constructor() {
+    super(
+      '이벤트 수정 중 오류가 발생했습니다.',
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+}
+
+export class deleteEventFailException extends HttpException {
+  constructor() {
+    super(
+      '이벤트 삭제 중 오류가 발생했습니다.',
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
+}

--- a/backend/src/follow/exception/follow.exception.ts
+++ b/backend/src/follow/exception/follow.exception.ts
@@ -1,0 +1,25 @@
+import { HttpException } from '@nestjs/common';
+
+export class NoSuchUserException extends HttpException {
+  constructor() {
+    super('존재하지 않는 사용자입니다.', 400);
+  }
+}
+
+export class FollowSelfException extends HttpException {
+  constructor() {
+    super('자기 자신은 팔로우할 수 없습니다.', 400);
+  }
+}
+
+export class AlreadyFollowException extends HttpException {
+  constructor() {
+    super('이미 팔로우한 사용자입니다.', 400);
+  }
+}
+
+export class NotFollowingException extends HttpException {
+  constructor() {
+    super('팔로우하고 있지 않습니다.', 400);
+  }
+}


### PR DESCRIPTION
## 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

Issue: #28

## 설명

<!-- 

- 현재 Pr 설명 

-->

`save()`에 배열을 인자로 넣었을 때 한 번의 insert가 아닌 배열의 길이만큼 insert를 반복하여 `insert()`로 변경했습니다.

repeatPolicy의 repeatEndDate와 타인의 일정 스토리를 조회할 수 없는 버그를 수정했습니다.

### 응답 시간 비교

한 달간 매일 반복되는 이벤트를 생성하는 경우를 기준으로 하였습니다.

<img width="643" alt="image" src="https://github.com/boostcampwm2023/and08-meetmeet/assets/79151181/2ef9b5d0-56c5-4dee-9aae-80a75668f9c6">

변경 전에는 응답 시간이 2.2s ~ 2.3s 정도였지만

<img width="677" alt="image" src="https://github.com/boostcampwm2023/and08-meetmeet/assets/79151181/eff03ee2-f10b-43ae-b650-5c9ea4f6ef2d">

변경 후에는 430~500ms 정도로 80%정도 단축되었습니다.

#### +) save, promise.all, insert 비교 (30개의 엔티티를 생성하는 경우)

- save
```typescript
await this.eventRepository.save(events);
```
<img width="300" alt="image" src="https://github.com/boostcampwm2023/and08-meetmeet/assets/79151181/14eeeb01-2c05-47fd-8480-e1dc2874a127">


- Promise.all
```typescript
await Promise.all(
  events.map(
    async((event) => {
      await this.eventRepository.save(event);
    }),
  ),
);
```
<img width="300" alt="image" src="https://github.com/boostcampwm2023/and08-meetmeet/assets/79151181/3d55e45e-9007-4279-a56f-46642e6af788">



- insert
save를 할 경우에는 저장된 엔티티를 반환해주지만 insert는 InsertResult를 반환하여 다시 select를 통해 엔티티를 조회하도록 했습니다.
```typescript
const result = await this.eventRepository.insert(events);

await this.eventRepository.find({
  where: { id: In(result.identifiers.map((identifier) => identifier.id)) },
});
```
<img width="300" alt="image" src="https://github.com/boostcampwm2023/and08-meetmeet/assets/79151181/71f80729-3712-46ea-8241-9f7236bb2f28">



## 고민거리 

<!-- (Optional) 의견 받고싶은 부분 있으면 적어두기

### Q. ui 이벤트 처리를 어디서 해야할 지 모르겠어요...

-->

eventMember를 select할 때 join이 5번씩 이루어지고 있어 개선이 더 필요할 것 같습니다..