### PR TITLE
Feature/backend/#42 update event: eventId로 피드 삭제 함수 구현 및 feed API 관련 오류 수정

### DIFF
--- a/backend/src/comment/comment.service.ts
+++ b/backend/src/comment/comment.service.ts
@@ -35,4 +35,11 @@ export class CommentService {
   async deleteComment(id: number) {
     await this.commentRepository.softDelete(id);
   }
+
+  async deleteComments(idList: number[]) {
+    if (!idList.length) {
+      return;
+    }
+    await this.commentRepository.softDelete(idList);
+  }
 }

--- a/backend/src/content/content.service.ts
+++ b/backend/src/content/content.service.ts
@@ -62,6 +62,9 @@ export class ContentService {
   }
 
   async softDeleteContent(idList: number[]) {
+    if (!idList.length) {
+      return;
+    }
     const files = await this.contentRepository.find({
       where: { id: In(idList) },
     });

--- a/backend/src/feed/entities/feed.entity.ts
+++ b/backend/src/feed/entities/feed.entity.ts
@@ -25,8 +25,6 @@ export class Feed extends commonEntity {
   @OneToMany(() => FeedContent, (feedContent) => feedContent.feed)
   feedContents: FeedContent[];
 
-  @OneToMany(() => Comment, (comment) => comment.feed, {
-    cascade: ['soft-remove'],
-  })
+  @OneToMany(() => Comment, (comment) => comment.feed)
   comments: Comment[];
 }

--- a/backend/src/feed/feed.service.ts
+++ b/backend/src/feed/feed.service.ts
@@ -142,7 +142,10 @@ export class FeedService {
       );
     }
 
-    await this.feedRepository.softRemove(feed);
+    await this.commentService.deleteComments(
+      feed.comments.map((comment) => comment.id),
+    );
+    await this.feedRepository.softDelete(feed.id);
   }
 
   async createComment(user: User, feedId: number, memo: string) {

--- a/backend/src/feed/feed.service.ts
+++ b/backend/src/feed/feed.service.ts
@@ -68,6 +68,7 @@ export class FeedService {
         'feed.id',
         'feed.memo',
         'feed.author',
+        'author.profile',
         'fc.contentId',
         'fc.content',
         'comment',
@@ -75,6 +76,7 @@ export class FeedService {
       .leftJoin('feed.feedContents', 'fc')
       .leftJoin('feed.comments', 'comment')
       .leftJoinAndSelect('feed.author', 'author')
+      .leftJoinAndSelect('author.profile', 'profile')
       .leftJoinAndSelect('fc.content', 'content')
       .where('feed.id = :id', { id })
       .getOne();


### PR DESCRIPTION
## 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

Issue: #30 #33 #42

## 설명

<!-- 

- 현재 Pr 설명 

-->

- 피드 조회 시 작성자의 프로필이 조회되지 않는 오류를 수정
  - author.profile join으로 해결
- 피드 삭제 시 발생하는 쿼리 에러 해결
  - 정확한 원인은 알 수 없지만 일단 softRemove가 문제인 듯 하여 cascade를 제거하고 softDelete로 변경
  - softRemove로 바꾸고도 테스트를 해봤었는데 무슨 문제인지는 모르겠습니다...
<img width="621" alt="image" src="https://github.com/boostcampwm2023/and08-meetmeet/assets/79151181/75c6ee43-9843-461c-b974-1e8d2721161c">
- 이벤트 삭제 시 해당 이벤트의 피드를 전부 삭제하는 메서드 구현

