### PR TITLE
[Feature/backend/#26 noti] 참여중으로 나타나는 버그 수정 및 알림삭제 기능 추가

### DIFF
--- a/backend/src/invite/exception/invite.exception.ts
+++ b/backend/src/invite/exception/invite.exception.ts
@@ -1,0 +1,19 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class NotExistInviteException extends HttpException {
+  constructor() {
+    super('존재하지 않는 초대입니다.', HttpStatus.NOT_FOUND);
+  }
+}
+
+export class InvalidInviteException extends HttpException {
+  constructor() {
+    super('유효하지 않은 초대입니다.', HttpStatus.BAD_REQUEST);
+  }
+}
+
+export class NotExistStatusException extends HttpException {
+  constructor() {
+    super('존재하지 않는 초대 상태입니다.', HttpStatus.NOT_FOUND);
+  }
+}

--- a/backend/src/invite/invite.service.ts
+++ b/backend/src/invite/invite.service.ts
@@ -7,6 +7,12 @@ import { Equal, Repository } from 'typeorm';
 import { StatusEnum } from './entities/status.enum';
 import { Status } from './entities/status.entity';
 import { Event } from '../event/entities/event.entity';
+import { logger } from '../common/log/winston.logger';
+import {
+  InvalidInviteException,
+  NotExistInviteException,
+  NotExistStatusException,
+} from './exception/invite.exception';
 @Injectable()
 export class InviteService {
   constructor(
@@ -68,9 +74,7 @@ export class InviteService {
       },
       token: fcmToken,
     };
-    if (!(await this.sendFireBaseMessage(message))) {
-      await this.updateInvite(invite.id, StatusEnum.Error);
-    }
+    await this.sendFireBaseMessage(message);
   }
 
   async sendFireBaseMessage(message: admin.messaging.Message) {
@@ -79,11 +83,19 @@ export class InviteService {
         .messaging()
         .send(message)
         .then((response) => {
-          console.log('Successfully sent message:', response);
+          logger.info(
+            'Successfully sent message:',
+            response,
+            `${JSON.stringify(message)}`,
+          );
         });
       return true;
     } catch (error) {
-      console.log('Error sending message:', error);
+      logger.error(
+        `sendInviteEventMessage error: ${JSON.stringify(
+          error,
+        )} / ${JSON.stringify(message)}`,
+      );
       return false;
     }
   }
@@ -120,6 +132,26 @@ export class InviteService {
     }
 
     return await this.inviteRepository.save(invite);
+  }
+
+  async updateInviteWhenJoinEvent(user: User, event: Event) {
+    const pendingStatus = await this.statusRepository.findOne({
+      where: { displayName: StatusEnum.Pending },
+    });
+    const acceptedStatus = await this.statusRepository.findOne({
+      where: { displayName: StatusEnum.Accepted },
+    });
+    if (!pendingStatus || !acceptedStatus) {
+      throw new NotExistStatusException();
+    }
+    await this.inviteRepository.update(
+      {
+        receiver: Equal(user.id),
+        event: Equal(event.id),
+        status: pendingStatus,
+      },
+      { status: { id: acceptedStatus.id } },
+    );
   }
 
   async updateInvite(inviteId: number, status: StatusEnum) {
@@ -160,6 +192,15 @@ export class InviteService {
     });
   }
 
+  async getInviteByEventAndUser(event: Event, user: User) {
+    return await this.inviteRepository.find({
+      where: { event: Equal(event.id), receiver: Equal(user.id) },
+      relations: ['sender', 'receiver'],
+      take: 1,
+      order: { id: 'DESC' },
+    });
+  }
+
   transformStatusEnumResponse(status: StatusEnum) {
     if (status === StatusEnum.Accepted) {
       return StatusEnum.Accepted;
@@ -168,5 +209,19 @@ export class InviteService {
     } else {
       return StatusEnum.Joinable;
     }
+  }
+
+  async deleteInvite(inviteId: number, user: User) {
+    const invite = await this.inviteRepository.findOne({
+      where: { id: inviteId },
+      relations: ['receiver'],
+    });
+    if (!invite) {
+      throw new NotExistInviteException();
+    }
+    if (invite.receiver.id !== user.id) {
+      throw new InvalidInviteException();
+    }
+    await this.inviteRepository.softDelete(inviteId);
   }
 }

--- a/backend/src/user/exception/user.exception.ts
+++ b/backend/src/user/exception/user.exception.ts
@@ -23,3 +23,9 @@ export class UserNotFoundException extends HttpException {
     super('존재하지 않는 사용자입니다.', HttpStatus.NOT_FOUND);
   }
 }
+
+export class QueryIntException extends HttpException {
+  constructor() {
+    super('int 형식이 아닌 아이디가 들어왔습니다.', HttpStatus.BAD_REQUEST);
+  }
+}

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -185,4 +185,18 @@ export class UserController {
     }
     return this.userService.getUserNotification(user, page);
   }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete('notification')
+  @ApiOperation({
+    summary: '사용자 알림 삭제 API',
+  })
+  @ApiQuery({
+    name: 'ids',
+    required: true,
+    example: '1,2,3',
+  })
+  deleteUserNotification(@GetUser() user: User, @Query('ids') ids: string) {
+    return this.userService.deleteUserNotification(user, ids);
+  }
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -11,6 +11,7 @@ import { SearchResponseDto } from '../event/dto/search-response.dto';
 import {
   DuplicatedNicknameException,
   NoSuchOauthProviderException,
+  QueryIntException,
   UserNotFoundException,
 } from './exception/user.exception';
 
@@ -247,5 +248,24 @@ export class UserService {
       }
     });
     return result;
+  }
+
+  async deleteUserNotification(user: User, ids: string) {
+    const idList = this.parseNumberString(ids);
+    await Promise.all(
+      idList.map(async (id) => {
+        await this.inviteService.deleteInvite(id, user);
+      }),
+    );
+  }
+
+  private parseNumberString(numberString: string) {
+    return numberString.split(',').map((item) => {
+      const parsedNumber = parseInt(item.trim(), 10);
+      if (isNaN(parsedNumber)) {
+        throw new QueryIntException();
+      }
+      return parsedNumber;
+    });
   }
 }


### PR DESCRIPTION
## 개요

참여중으로 나타나는 버그 및 알림 삭제기능을 추가하였습니다.

## 설명
- 일정에 참여하지 않아도 참여중으로 나타났던 버그는 참여중이 아닐때에 invite 테이블을 조회하는데, 그때 여러개를 조회하면서 이전에 accepted 된 데이터를 반영하게 되었습니다.
- 새로운 데이터를 조회하면서 desc와 limit를 이용하여 가장 최신의 데이터를 반영하도록 변경하였습니다.

- 알람 삭제 기능을 추가하여 사용자가 불필요한 알람을 삭제할 수 있게 만들었습니다.

## 고민거리 

### Q. depth 문제
```Javascript
if (!eventMember) {
  invites.find(async (invite) => {
    if (invite.receiver.id === follower.follower.id) {
      const inviteByEventAndUserLimitOne =
        await this.inviteService.getInviteByEventAndUser(
          event,
          follower.follower,
        );
      if (inviteByEventAndUserLimitOne) {
        isJoined = this.inviteService.transformStatusEnumResponse(
          inviteByEventAndUserLimitOne[0].status.displayName,
        );
      } else {
        isJoined = StatusEnum.Joinable;
      }
    }
  });
  if (!isJoined) {
    isJoined = StatusEnum.Joinable;
  }
} else {
  isJoined = StatusEnum.Accepted;
}
``` 
- 점차 depth가 깊어져 이를 다른 메서드로 분리하는게 좋을 것 같지만, 리팩토링을 조금 뒤로 미루도록 하는 것이 좋을 것 같아 우선 PR을 올립니다.
