### PR TITLE
Feature/backend/#42 update event

### DIFF
--- a/backend/src/content/content.service.ts
+++ b/backend/src/content/content.service.ts
@@ -82,6 +82,8 @@ export class ContentService {
   }
 
   generateFilePath(dir: string, fileName: string) {
-    return `${dir}/${uuidv4().split('-').slice(2).join()}${extname(fileName)}`;
+    return `${dir}/${uuidv4().split('-').slice(2).join('')}${extname(
+      fileName,
+    )}`;
   }
 }

--- a/backend/src/detail/detail.service.ts
+++ b/backend/src/detail/detail.service.ts
@@ -37,22 +37,22 @@ export class DetailService {
   }
 
   async updateDetail(detail: Detail, createScheduleDto: CreateScheduleDto) {
-    return await this.detailRepository.save({
-      ...detail,
-      ...createScheduleDto,
-    });
+    await this.detailRepository.save({ ...detail, ...createScheduleDto });
   }
 
-  async deleteDetail(detail: Detail) {
-    return await this.detailRepository.softDelete(detail.id);
+  async deleteDetailsById(idList: number[]) {
+    if (!idList.length) {
+      return;
+    }
+    await this.detailRepository.softDelete(idList);
   }
 
-  async bulkUpdateDetail(detailIds: number[], detail: Detail) {
-    await this.detailRepository
-      .createQueryBuilder('detail')
-      .update()
-      .set(detail)
-      .whereInIds(detailIds)
-      .execute();
+  async updateDetailBulk(
+    detailIds: number[],
+    createScheduleDto: CreateScheduleDto,
+  ) {
+    const detail = this.detailRepository.create({ ...createScheduleDto });
+
+    await this.detailRepository.update(detailIds, detail);
   }
 }

--- a/backend/src/event-member/entities/eventMember.entity.ts
+++ b/backend/src/event-member/entities/eventMember.entity.ts
@@ -15,7 +15,6 @@ export class EventMember extends commonEntity {
 
   @OneToOne(() => Detail, {
     nullable: false,
-    cascade: ['soft-remove'],
     eager: true,
   })
   @JoinColumn()

--- a/backend/src/event-member/event-member.module.ts
+++ b/backend/src/event-member/event-member.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { EventMember } from './entities/eventMember.entity';
 import { Authority } from './entities/authority.entity';
 import { EventMemberService } from './event-member.service';
+import { DetailModule } from 'src/detail/detail.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([EventMember, Authority])],
+  imports: [TypeOrmModule.forFeature([EventMember, Authority]), DetailModule],
   providers: [EventMemberService],
   exports: [EventMemberService],
 })

--- a/backend/src/event/dto/create-event-response.dto.ts
+++ b/backend/src/event/dto/create-event-response.dto.ts
@@ -15,7 +15,7 @@ export class CreateEventResponse {
   @ApiProperty()
   isJoinable: boolean;
   @ApiProperty()
-  repeatPolicyId: number;
+  repeatPolicyId: number | null;
   @ApiProperty()
   announcement: string | null;
   @ApiProperty()

--- a/backend/src/event/dto/create-event-response.dto.ts
+++ b/backend/src/event/dto/create-event-response.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { EventMember } from 'src/event-member/entities/eventMember.entity';
+
+export class CreateEventResponse {
+  @ApiProperty()
+  id: number;
+  @ApiProperty()
+  title: string;
+  @ApiProperty()
+  startDate: string;
+  @ApiProperty()
+  endDate: string;
+  @ApiProperty()
+  authority: string | null;
+  @ApiProperty()
+  isJoinable: boolean;
+  @ApiProperty()
+  repeatPolicyId: number;
+  @ApiProperty()
+  announcement: string | null;
+  @ApiProperty()
+  isVisible: boolean;
+  @ApiProperty()
+  memo: string | null;
+  @ApiProperty()
+  color: number;
+  @ApiProperty()
+  alarmMinutes: number;
+
+  static of(eventMember: EventMember): CreateEventResponse {
+    return {
+      id: eventMember.event.id,
+      startDate: eventMember.event.startDate.toISOString(),
+      endDate: eventMember.event.endDate.toISOString(),
+      title: eventMember.event.title,
+      repeatPolicyId: eventMember.event.repeatPolicyId,
+      isJoinable: eventMember.event.isJoinable ? true : false,
+      announcement: eventMember.event.announcement,
+      isVisible: eventMember.detail.isVisible ? true : false,
+      memo: eventMember.detail.memo,
+      color: eventMember.detail.color,
+      alarmMinutes: eventMember.detail.alarmMinutes,
+      authority: eventMember.authority.displayName,
+    };
+  }
+}

--- a/backend/src/event/entities/event.entity.ts
+++ b/backend/src/event/entities/event.entity.ts
@@ -26,13 +26,12 @@ export class Event extends commonEntity {
   announcement: string | null;
 
   @Column({ nullable: true })
-  repeatPolicyId: number;
+  repeatPolicyId: number | null;
 
   @ManyToOne(() => RepeatPolicy, (repeatPolicy) => repeatPolicy.events)
   repeatPolicy: RepeatPolicy;
 
   @OneToMany(() => EventMember, (eventMember) => eventMember.event, {
-    cascade: ['soft-remove'],
     eager: true,
   })
   eventMembers: EventMember[];

--- a/backend/src/event/exception/event.exception.ts
+++ b/backend/src/event/exception/event.exception.ts
@@ -6,6 +6,12 @@ export class EventNotFoundException extends HttpException {
   }
 }
 
+export class EventPropertyNotFoundException extends HttpException {
+  constructor() {
+    super('일정 속성을 전부 입력해주세요.', HttpStatus.NOT_FOUND);
+  }
+}
+
 export class EventDetailNotFoundException extends HttpException {
   constructor() {
     super('일정 내용을 찾을 수 없습니다.', HttpStatus.NOT_FOUND);
@@ -32,6 +38,12 @@ export class AlreadyJoinedException extends HttpException {
 export class InvalidRepeatPolicyException extends HttpException {
   constructor() {
     super('올바르지 않은 반복 설정입니다.', HttpStatus.BAD_REQUEST);
+  }
+}
+
+export class UpdateAllRepeatEventsException extends HttpException {
+  constructor() {
+    super('이후의 반복 일정을 전부 업데이트해야 합니다.', 423);
   }
 }
 


### PR DESCRIPTION
## 개요

<!-- 

- 이슈번호
- 한줄 설명
 
-->

Issue: #42 

## 설명

<!-- 

- 현재 Pr 설명 

-->

- update event 관련하여 발견된 버그를 수정하고 리팩토링했습니다.
- cascade를 제거하고 각 엔티티별로 삭제해주도록 수정했습니다.

1. 멤버일 경우 디테일만 수정
2. 오너일 경우
    1. 이후 일정 전부 수정일 경우
        1. 반복 정책이 같은 경우 (startDate, endDate, repeatPolicy 3가지가 모두 동일한 경우)
            detail과 event를 업데이트
        2. 반복 정책이 다를 경우
            피드가 존재하지 않는 이벤트들을 전부 삭제 (관련된 eventMember도 전부 삭제)
            기존 일정을 업데이트하고 새로운 반복 정책과 새로운 일정 생성 후 기존 일정에 새로운 반복 정책 id 부여
    2. 단일 일정 수정일 경우
        1. 기존에 반복 일정 !== 새로운 반복 일정 (startDate, endDate, repeatPolicy 3가지 중 하나라도 다를 경우)
             뒤의 일정을 전부 삭제하고 새로 생성하는 경우에는 isAll이 true인 경우와 다를바가 없어보여 안드로이드와 협의 하에 423 에러를 뱉도록 했습니다.
         2. 그 외에
             detail과 event 업데이트, repeatPolicy id 제거

## 고민거리 

<!-- (Optional) 의견 받고싶은 부분 있으면 적어두기

### Q. ui 이벤트 처리를 어디서 해야할 지 모르겠어요...

-->

간단히 테스트를 해보긴 했는데 아직 모든 케이스를 테스트해보진 못해서 추가적인 테스트가 필요할 것 같습니다.
업데이트 이외에도 삭제하는 부분이 약간 수정되어 확인 부탁드립니다.

